### PR TITLE
Add scroll_step option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -45,6 +45,7 @@ dillo-3.1 [not released yet]
  - Fix OSX compilation issue with xembed.
    Patches: Johannes Hofmann
 +- Fix DuckDuckGo search links
+ - Add scroll_step option to control the mouse wheel vertical step
    Patches: Rodrigo Arias Mallo <rodarima@gmail.com>
 
 -----------------------------------------------------------------------------

--- a/dillorc
+++ b/dillorc
@@ -40,6 +40,9 @@
 # Set your default directory for download/save operations
 #save_dir=/tmp
 
+# Mouse wheel scroll step in pixels
+#scroll_step=100
+
 #-------------------------------------------------------------------------
 #                           RENDERING SECTION
 #-------------------------------------------------------------------------

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -81,6 +81,7 @@ void a_Prefs_init(void)
    prefs.panel_size = P_medium;
    prefs.parse_embedded_css=TRUE;
    prefs.save_dir = dStrdup(PREFS_SAVE_DIR);
+   prefs.scroll_step = 100;
    prefs.search_urls = dList_new(16);
    dList_append(prefs.search_urls, dStrdup(PREFS_SEARCH_URL));
    prefs.search_url_idx = 0;

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -72,6 +72,7 @@ typedef struct {
    double font_factor;
    int32_t font_max_size;
    int32_t font_min_size;
+   int32_t scroll_step;
    bool_t show_back;
    bool_t show_forw;
    bool_t show_home;

--- a/src/prefsparser.cc
+++ b/src/prefsparser.cc
@@ -189,6 +189,7 @@ void PrefsParser::parse(FILE *fp)
       { "panel_size", &prefs.panel_size, PREFS_PANEL_SIZE, 0 },
       { "parse_embedded_css", &prefs.parse_embedded_css, PREFS_BOOL, 0 },
       { "save_dir", &prefs.save_dir, PREFS_STRING, 0 },
+      { "scroll_step", &prefs.scroll_step, PREFS_INT32, 0 },
       { "search_url", &prefs.search_urls, PREFS_STRINGS, 0 },
       { "show_back", &prefs.show_back, PREFS_BOOL, 0 },
       { "show_bookmarks", &prefs.show_bookmarks, PREFS_BOOL, 0 },

--- a/src/uicmd.cc
+++ b/src/uicmd.cc
@@ -607,7 +607,7 @@ static BrowserWindow *UIcmd_tab_new(CustTabs *tabs, UI *old_ui, int focus)
    viewport->setDragScroll (prefs.middle_click_drags_page ? true : false);
    layout->attachView (viewport);
    new_ui->set_render_layout(viewport);
-   viewport->setScrollStep((int) rint(28.0 * prefs.font_factor));
+   viewport->setScrollStep(prefs.scroll_step);
 
    // Now, create a new browser window structure
    BrowserWindow *new_bw = a_Bw_new();


### PR DESCRIPTION
When using the mouse wheel to scroll a page, the default scroll step was causing a very slow scrolling speed. The new option "scroll_step" allows the user to define how many pixels the page is moved in every step of the mouse wheel. The default is increased to 100 pixels per step.

Here is an example where a [large page](https://html.spec.whatwg.org/#a-quick-introduction-to-html) is loaded in the original Dillo in the left and the version with the increased scroll step to 100 in the right. When using the mouse wheel the screen is moved much faster now:

[video.webm](https://github.com/dillo-browser/dillo/assets/3866127/592b7d1c-b62a-492f-80ab-6bf3ded3689d)


Fixes #22 