### PR TITLE
Add support for OpenSSL 1.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,26 @@ jobs:
       run: make check
     - name: make distcheck
       run: make distcheck
-  build-openssl:
+  build-openssl-3:
     runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Install FLTK
+      run: sudo apt install -y libfltk1.3-dev libssl-dev
+    - name: autogen
+      run: ./autogen.sh
+    - name: configure
+      run: ./configure --disable-mbedtls
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck
+  build-openssl-1-1:
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
       with:

--- a/ChangeLog
+++ b/ChangeLog
@@ -46,7 +46,7 @@ dillo-3.1 [not released yet]
    Patches: Johannes Hofmann
 +- Fix DuckDuckGo search links
  - Add scroll_step option to control the mouse wheel vertical step
- - Add support for OpenSSL, mbedTLS 2 and mbedTLS 3
+ - Add support for OpenSSL 1.1, OpenSSL 3, mbedTLS 2 and mbedTLS 3
  - Replace configure flag --enable-ssl to --enable-tls
  - Enable TLS support by default for https.
    Patches: Rodrigo Arias Mallo <rodarima@gmail.com>

--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+README.md

--- a/doc/install.md
+++ b/doc/install.md
@@ -20,7 +20,7 @@ Additionally, it is **strongly recommended** that you install a TLS
 library to browse HTTPS pages. Currently, Dillo supports any of the
 following libraries:
 
- - OpenSSL
+ - OpenSSL 1.1 or 3
  - mbedTLS 2 or 3
 
 If you don't want to use a TLS library, use the configure option

--- a/src/IO/tls_openssl.c
+++ b/src/IO/tls_openssl.c
@@ -834,6 +834,7 @@ static int Tls_examine_certificate(SSL *ssl, Server_t *srv)
          ret = 0;
          break;
       case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
+         ; /* Case follows declaration */
          /* Either self signed and untrusted */
          /* Extract CN from certificate name information */
          X509_NAME *subject_name = X509_get_subject_name(remote_cert);

--- a/src/IO/tls_openssl.c
+++ b/src/IO/tls_openssl.c
@@ -491,7 +491,11 @@ static bool_t Tls_check_cert_strength(SSL *ssl, Server_t *srv, int *choice)
          if (print_chain)
             MSG("%s ", buf);
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+         key_type = EVP_PKEY_type(EVP_PKEY_id(public_key));
+#else
          key_type = EVP_PKEY_type(EVP_PKEY_get_id(public_key));
+#endif
          type_str = key_type == EVP_PKEY_RSA ? "RSA" :
                     key_type == EVP_PKEY_DSA ? "DSA" :
                     key_type == EVP_PKEY_DH ? "DH" :


### PR DESCRIPTION
The function is not available in OpenSSL 1.1 with the `_get` suffix.