### PR TITLE
Fix min-width and max-width CSS attributes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,139 +3,6 @@ name: CI
 on: [push]
 
 jobs:
-  ubuntu-latest-no-tls:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
-    - name: Install dependencies
-      run: sudo apt install -y libfltk1.3-dev
-    - name: autogen
-      run: ./autogen.sh
-    - name: configure
-      run: ./configure --disable-tls
-    - name: make
-      run: make
-    - name: make check
-      run: make check
-    - name: make distcheck
-      run: make distcheck
-  ubuntu-latest-mbedtls2:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
-    - name: Install dependencies
-      run: sudo apt install -y libfltk1.3-dev libmbedtls-dev
-    - name: autogen
-      run: ./autogen.sh
-    - name: configure
-      run: ./configure --disable-openssl
-    - name: make
-      run: make
-    - name: make check
-      run: make check
-    - name: make distcheck
-      run: make distcheck
-  ubuntu-latest-openssl-3:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
-    - name: Install dependencies
-      run: sudo apt install -y libfltk1.3-dev libssl-dev
-    - name: autogen
-      run: ./autogen.sh
-    - name: configure
-      run: ./configure --disable-mbedtls
-    - name: make
-      run: make
-    - name: make check
-      run: make check
-    - name: make distcheck
-      run: make distcheck
-  ubuntu-20-04-openssl-1-1:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
-    - name: Install dependencies
-      run: sudo apt install -y libfltk1.3-dev libssl-dev
-    - name: autogen
-      run: ./autogen.sh
-    - name: configure
-      run: ./configure --disable-mbedtls
-    - name: make
-      run: make
-    - name: make check
-      run: make check
-    - name: make distcheck
-      run: make distcheck
-  macOS-13-openssl-1-1:
-    runs-on: macos-13
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
-    - name: Install dependencies
-      run: brew install autoconf automake fltk
-    - name: autogen
-      run: ./autogen.sh
-    - name: configure
-      run: ./configure --disable-mbedtls
-    - name: make
-      run: make
-    - name: make check
-      run: make check
-    - name: make distcheck
-      run: make distcheck
-  macOS-13-openssl-3:
-    runs-on: macos-13
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
-    - name: Remove old OpenSSL 1.1
-      run: brew uninstall openssl@1.1
-    - name: Install dependencies
-      run: brew install autoconf automake fltk openssl@3
-    - name: autogen
-      run: ./autogen.sh
-    - name: configure
-      run: ./configure --disable-mbedtls
-    - name: make
-      run: make
-    - name: make check
-      run: make check
-    - name: make distcheck
-      run: make distcheck
-  freebsd-14-openssl-3:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: FreeBSD VM build
-      id: test
-      uses: vmactions/freebsd-vm@v1
-      with:
-        release: "14.0"
-        usesh: true
-        prepare: |
-          set -x
-          pkg install -y automake fltk
-        run: |
-          set -x
-          pwd
-          freebsd-version
-          ./autogen.sh
-          ./configure CPPFLAGS='-I/usr/local/include' LDFLAGS='-L/usr/local/lib'
-          cat config.log
-          make
-          make check
-          ldd src/dillo
   ubuntu-latest-html-tests:
     runs-on: ubuntu-latest
     steps:
@@ -171,3 +38,143 @@ jobs:
 #       name: upload-html-test-results
 #       path: |
 #         build/test/html
+  ubuntu-latest-no-tls:
+    needs: ubuntu-latest-html-tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Install dependencies
+      run: sudo apt install -y libfltk1.3-dev
+    - name: autogen
+      run: ./autogen.sh
+    - name: configure
+      run: ./configure --disable-tls
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck
+  ubuntu-latest-mbedtls2:
+    needs: ubuntu-latest-html-tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Install dependencies
+      run: sudo apt install -y libfltk1.3-dev libmbedtls-dev
+    - name: autogen
+      run: ./autogen.sh
+    - name: configure
+      run: ./configure --disable-openssl
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck
+  ubuntu-latest-openssl-3:
+    needs: ubuntu-latest-html-tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Install dependencies
+      run: sudo apt install -y libfltk1.3-dev libssl-dev
+    - name: autogen
+      run: ./autogen.sh
+    - name: configure
+      run: ./configure --disable-mbedtls
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck
+  ubuntu-20-04-openssl-1-1:
+    needs: ubuntu-latest-html-tests
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Install dependencies
+      run: sudo apt install -y libfltk1.3-dev libssl-dev
+    - name: autogen
+      run: ./autogen.sh
+    - name: configure
+      run: ./configure --disable-mbedtls
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck
+  macOS-13-openssl-1-1:
+    needs: ubuntu-latest-html-tests
+    runs-on: macos-13
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Install dependencies
+      run: brew install autoconf automake fltk
+    - name: autogen
+      run: ./autogen.sh
+    - name: configure
+      run: ./configure --disable-mbedtls
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck
+  macOS-13-openssl-3:
+    needs: ubuntu-latest-html-tests
+    runs-on: macos-13
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Remove old OpenSSL 1.1
+      run: brew uninstall openssl@1.1
+    - name: Install dependencies
+      run: brew install autoconf automake fltk openssl@3
+    - name: autogen
+      run: ./autogen.sh
+    - name: configure
+      run: ./configure --disable-mbedtls
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck
+  freebsd-14-openssl-3:
+    needs: ubuntu-latest-html-tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: FreeBSD VM build
+      id: test
+      uses: vmactions/freebsd-vm@v1
+      with:
+        release: "14.0"
+        usesh: true
+        prepare: |
+          set -x
+          pkg install -y automake fltk
+        run: |
+          set -x
+          pwd
+          freebsd-version
+          ./autogen.sh
+          ./configure CPPFLAGS='-I/usr/local/include' LDFLAGS='-L/usr/local/lib'
+          cat config.log
+          make
+          make check
+          ldd src/dillo

--- a/ChangeLog
+++ b/ChangeLog
@@ -50,6 +50,7 @@ dillo-3.1 [not released yet]
  - Replace configure flag --enable-ssl to --enable-tls
  - Enable TLS support by default for https.
  - Add automatic rendering tests (only enabled with --enable-html-tests).
+ - Fix width calculation when using 'min-width' and 'max-width'.
    Patches: Rodrigo Arias Mallo <rodarima@gmail.com>
 
 -----------------------------------------------------------------------------

--- a/dw/textblock.cc
+++ b/dw/textblock.cc
@@ -2,6 +2,7 @@
  * Dillo Widget
  *
  * Copyright 2005-2007, 2012-2014 Sebastian Geerken <sgeerken@dillo.org>
+ * Copyright 2023 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -552,7 +553,7 @@ void Textblock::notifySetParent ()
          // avoid dublicates
          bool found = false;
          for (int j = 0; !found && j < numSizeReferences; j++)
-            if (oofContainer[i] == oofContainer[i])
+            if (oofContainer[i] == oofContainer[j])
                found = true;
 
          if (!found)

--- a/dw/widget.cc
+++ b/dw/widget.cc
@@ -2,6 +2,7 @@
  * Dillo Widget
  *
  * Copyright 2005-2007 Sebastian Geerken <sgeerken@dillo.org>
+ * Copyright 2023 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -641,28 +642,24 @@ int Widget::getMinWidth (Extremes *extremes, bool forceValue)
 /**
  * Return available width including margin/border/padding
  * (extraSpace?), not only the content width.
+ *
+ * If the widget has a parent or a quasiParent, the width computation is
+ * delegated to the parent first, or the quasiParent later.
  */
 int Widget::getAvailWidth (bool forceValue)
 {
    DBG_OBJ_ENTER ("resize", 0, "getAvailWidth", "%s",
                   forceValue ? "true" : "false");
 
-   int width;
+   int width = -1;
+   int scrollbarThickness =
+      layout->canvasHeightGreater ? layout->vScrollbarThickness : 0;
+   int viewportWidth = layout->viewportWidth - scrollbarThickness;
 
    if (parent == NULL && quasiParent == NULL) {
       DBG_OBJ_MSG ("resize", 1, "no parent, regarding viewport");
       DBG_OBJ_MSG_START ();
-
       // TODO Consider nested layouts (e. g. <button>).
-
-      int viewportWidth =
-         layout->viewportWidth - (layout->canvasHeightGreater ?
-                                  layout->vScrollbarThickness : 0);
-      width = -1;
-      calcFinalWidth (getStyle (), viewportWidth, NULL, 0, forceValue, &width);
-      if (width == -1)
-         width = viewportWidth;
-
       DBG_OBJ_MSG_END ();
    } else if (parent) {
       DBG_OBJ_MSG ("resize", 1, "delegated to parent");
@@ -675,6 +672,15 @@ int Widget::getAvailWidth (bool forceValue)
       width = quasiParent->getAvailWidthOfChild (this, forceValue);
       DBG_OBJ_MSG_END ();
    }
+
+   /* The refWidth will be used for relative sizes. If not set, use the
+    * viewport width */
+   int refWidth = width == -1 ? viewportWidth : width;
+
+   /* Constraint the width with min-width and max-width */
+   calcFinalWidth (getStyle (), refWidth, NULL, 0, forceValue, &width);
+   if (width == -1)
+      width = refWidth;
 
    DBG_OBJ_LEAVE_VAL ("%d", width);
    return width;

--- a/dw/widget.cc
+++ b/dw/widget.cc
@@ -872,6 +872,16 @@ void Widget::correctExtremes (Extremes *extremes, bool useAdjustmentWidth)
    DBG_OBJ_LEAVE_VAL ("%d / %d", extremes->minWidth, extremes->maxWidth);
 }
 
+/** Computes a width value in pixels from cssValue.
+ *
+ * If cssValue is absolute, the absolute value is used.
+ * If cssValue is relative, then it is applied to refWidth.
+ * Otherwise, -1 is used.
+ *
+ * In any case, the returned value is clamped so that is not smaller
+ * than limitMinWidth.
+ *
+ */
 int Widget::calcWidth (style::Length cssValue, int refWidth, Widget *refWidget,
                        int limitMinWidth, bool forceValue)
 {
@@ -912,6 +922,10 @@ int Widget::calcWidth (style::Length cssValue, int refWidth, Widget *refWidget,
 }
 
 // *finalWidth may be -1.
+/*
+ * If style has minWidth or maxWidth set, the returned value in
+ * *finalWidth is constrained to not exceed any of the set limits.
+ * */
 void Widget::calcFinalWidth (style::Style *style, int refWidth,
                              Widget *refWidget, int limitMinWidth,
                              bool forceValue, int *finalWidth)
@@ -931,9 +945,12 @@ void Widget::calcFinalWidth (style::Style *style, int refWidth,
    
    if (width != -1)
       *finalWidth = width;
-   if (minWidth != -1 && *finalWidth != -1 && *finalWidth < minWidth)
+
+   /* Set the width if the min or max value is set and finalWidth is
+    * still -1 or exceeds the limit */
+   if (minWidth != -1 && (*finalWidth == -1 || *finalWidth < minWidth))
       *finalWidth = minWidth;
-   if (maxWidth != -1 && *finalWidth == -1 && *finalWidth > maxWidth)
+   if (maxWidth != -1 && (*finalWidth == -1 || *finalWidth > maxWidth))
       *finalWidth = maxWidth;
 
    DBG_OBJ_LEAVE_VAL ("%d", *finalWidth);

--- a/test/html/Makefile.am
+++ b/test/html/Makefile.am
@@ -6,11 +6,19 @@ AM_TESTS_ENVIRONMENT = env \
 LOG_COMPILER = $(srcdir)/driver.sh
 
 TESTS = \
+	render/b-div.html \
 	render/float-img-justify.html \
 	render/img-aspect-ratio.html \
+	render/max-width-body.html \
+	render/max-width-div.html \
+	render/max-width-html.html \
+	render/max-width-nested-div.html \
+	render/min-width-body.html \
+	render/min-width-div.html \
+	render/min-width-html.html \
+	render/min-width-nested-div.html \
 	render/table-thead-tfoot.html \
-	render/white-space.html \
-	render/b-div.html
+	render/white-space.html
 
 # To be fixed
 XFAIL_TESTS = \

--- a/test/html/Makefile.am
+++ b/test/html/Makefile.am
@@ -23,4 +23,6 @@ TESTS = \
 # To be fixed
 XFAIL_TESTS = \
 	render/float-img-justify.html \
-	render/img-aspect-ratio.html
+	render/img-aspect-ratio.html \
+	render/max-width-html.html \
+	render/min-width-html.html

--- a/test/html/manual/max-width-body.html
+++ b/test/html/manual/max-width-body.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test min-width and max-width CSS properties</title>
+    <style>
+      body {margin: 20px; min-width: 400px; max-width: 600px; background: lightgrey}
+      .min {width: 400px; background: lightgreen}
+      .max {width: 600px; background: lightgreen}
+    </style>
+  </head>
+  <body>
+    <div class="min">
+      <p>By resizing the window, the content below in gray should stay
+      within the limits of minimum and maximum width.</p>
+      <p>Minimum width 400 px</p>
+    </div>
+    <div>
+      <p>This is a rather long text to increase the maximal paragraph
+      width. Sed ut perspiciatis, unde omnis iste natus error sit
+      voluptatem accusantium doloremque laudantium, totam rem aperiam
+      eaque ipsa, quae ab illo inventore veritatis et quasi architecto
+      beatae vitae dicta sunt, explicabo. nemo enim ipsam voluptatem,
+      quia voluptas sit, aspernatur aut odit aut fugit, sed quia
+      consequuntur magni dolores eos, qui ratione voluptatem sequi
+      nesciunt, neque porro quisquam est, qui dolorem ipsum, quia dolor
+      sit, amet, consectetur, adipisci velit, sed quia non numquam eius
+      modi tempora incidunt, ut labore et dolore magnam aliquam quaerat
+      voluptatem. ut enim ad minima veniam, quis nostrum exercitationem
+      ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi
+      consequatur?</p>
+    </div>
+    <div class="max"><p>Maximum width 600 px</p></div>
+  </body>
+</html>

--- a/test/html/manual/max-width-div.html
+++ b/test/html/manual/max-width-div.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test min-width and max-width CSS properties</title>
+    <style>
+      body {margin: 20px}
+      .min {width: 400px; background: lightgreen}
+      .max {width: 600px; background: lightgreen}
+      .test {min-width: 400px; max-width: 600px; background: lightgrey}
+    </style>
+  </head>
+  <body>
+    <div class="min">
+      <p>By resizing the window, the content below in gray should stay
+      within the limits of minimum and maximum width.</p>
+      <p>Minimum width 400 px</p>
+    </div>
+    <div class="test">
+      <p>This is a rather long text to increase the maximal paragraph
+      width. Sed ut perspiciatis, unde omnis iste natus error sit
+      voluptatem accusantium doloremque laudantium, totam rem aperiam
+      eaque ipsa, quae ab illo inventore veritatis et quasi architecto
+      beatae vitae dicta sunt, explicabo. nemo enim ipsam voluptatem,
+      quia voluptas sit, aspernatur aut odit aut fugit, sed quia
+      consequuntur magni dolores eos, qui ratione voluptatem sequi
+      nesciunt, neque porro quisquam est, qui dolorem ipsum, quia dolor
+      sit, amet, consectetur, adipisci velit, sed quia non numquam eius
+      modi tempora incidunt, ut labore et dolore magnam aliquam quaerat
+      voluptatem. ut enim ad minima veniam, quis nostrum exercitationem
+      ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi
+      consequatur?</p>
+    </div>
+    <div class="max"><p>Maximum width 600 px</p></div>
+  </body>
+</html>

--- a/test/html/manual/max-width-html.html
+++ b/test/html/manual/max-width-html.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test min-width and max-width CSS properties</title>
+    <style>
+      html {max-width: 600px; background: lightgray}
+      body {margin: 7px}
+      .min {width: 400px; background: lightgreen}
+      .max {width: 600px; background: lightgreen}
+    </style>
+  </head>
+  <body>
+    <div class="min">
+      <p>By resizing the window, the content below in gray should stay
+      within the limits of minimum and maximum width.</p>
+      <p>Minimum width 400 px</p>
+    </div>
+    <div>
+      <p>This is a rather long text to increase the maximal paragraph
+      width. Sed ut perspiciatis, unde omnis iste natus error sit
+      voluptatem accusantium doloremque laudantium, totam rem aperiam
+      eaque ipsa, quae ab illo inventore veritatis et quasi architecto
+      beatae vitae dicta sunt, explicabo. nemo enim ipsam voluptatem,
+      quia voluptas sit, aspernatur aut odit aut fugit, sed quia
+      consequuntur magni dolores eos, qui ratione voluptatem sequi
+      nesciunt, neque porro quisquam est, qui dolorem ipsum, quia dolor
+      sit, amet, consectetur, adipisci velit, sed quia non numquam eius
+      modi tempora incidunt, ut labore et dolore magnam aliquam quaerat
+      voluptatem. ut enim ad minima veniam, quis nostrum exercitationem
+      ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi
+      consequatur?</p>
+    </div>
+    <div class="max"><p>Maximum width 600 px</p></div>
+  </body>
+</html>

--- a/test/html/manual/max-width-nested-div.html
+++ b/test/html/manual/max-width-nested-div.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test min-width and max-width CSS properties</title>
+    <style>
+      body {margin: 20px}
+      .test {min-width: 400px; max-width: 600px; background: lightgray}
+      .min {width: 400px; background: lightgreen}
+      .max {width: 600px; background: lightgreen}
+    </style>
+  </head>
+  <body>
+    <div class="background:lightblue">
+      <div class="min">
+        <p>By resizing the window, the content below in gray should stay
+        within the limits of minimum and maximum width.</p>
+        <p>Minimum width 400 px</p>
+      </div>
+      <div class="test">
+        <p>This is a rather long text to increase the maximal paragraph
+        width. Sed ut perspiciatis, unde omnis iste natus error sit
+        voluptatem accusantium doloremque laudantium, totam rem aperiam
+        eaque ipsa, quae ab illo inventore veritatis et quasi architecto
+        beatae vitae dicta sunt, explicabo. nemo enim ipsam voluptatem,
+        quia voluptas sit, aspernatur aut odit aut fugit, sed quia
+        consequuntur magni dolores eos, qui ratione voluptatem sequi
+        nesciunt, neque porro quisquam est, qui dolorem ipsum, quia dolor
+        sit, amet, consectetur, adipisci velit, sed quia non numquam eius
+        modi tempora incidunt, ut labore et dolore magnam aliquam quaerat
+        voluptatem. ut enim ad minima veniam, quis nostrum exercitationem
+        ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi
+        consequatur?</p>
+      </div>
+      <div class="max"><p>Maximum width 600 px</p></div>
+    </div>
+  </body>
+</html>

--- a/test/html/render/max-width-body.html
+++ b/test/html/render/max-width-body.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test max-width in body</title>
+    <style>
+      body {margin: 20px; max-width: 400px}
+    </style>
+  </head>
+  <body>
+    <div>
+      <p>The licenses for most software and other practical works are
+      designed to take away your freedom to share and change the works.
+      By contrast, the GNU General Public License is intended to
+      guarantee your freedom to share and change all versions of a
+      program--to make sure it remains free software for all its users.
+      We, the Free Software Foundation, use the GNU General Public
+      License for most of our software; it applies also to any other
+      work released this way by its authors. You can apply it to your
+      programs, too.</p>
+    </div>
+  </body>
+</html>

--- a/test/html/render/max-width-body.ref.html
+++ b/test/html/render/max-width-body.ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test max-width in body</title>
+    <style>
+      body {margin: 20px; width: 400px}
+    </style>
+  </head>
+  <body>
+    <div>
+      <p>The licenses for most software and other practical works are
+      designed to take away your freedom to share and change the works.
+      By contrast, the GNU General Public License is intended to
+      guarantee your freedom to share and change all versions of a
+      program--to make sure it remains free software for all its users.
+      We, the Free Software Foundation, use the GNU General Public
+      License for most of our software; it applies also to any other
+      work released this way by its authors. You can apply it to your
+      programs, too.</p>
+    </div>
+  </body>
+</html>

--- a/test/html/render/max-width-div.html
+++ b/test/html/render/max-width-div.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test max-width CSS properties</title>
+    <style>
+      body {margin: 20px}
+      .test {max-width: 600px; background: lightgrey}
+    </style>
+  </head>
+  <body>
+    <div class="test">
+      <p>The licenses for most software and other practical works are
+      designed to take away your freedom to share and change the works.
+      By contrast, the GNU General Public License is intended to
+      guarantee your freedom to share and change all versions of a
+      program--to make sure it remains free software for all its users.
+      We, the Free Software Foundation, use the GNU General Public
+      License for most of our software; it applies also to any other
+      work released this way by its authors. You can apply it to your
+      programs, too.</p>
+    </div>
+  </body>
+</html>

--- a/test/html/render/max-width-div.ref.html
+++ b/test/html/render/max-width-div.ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test max-width CSS properties</title>
+    <style>
+      body {margin: 20px}
+      .test {width: 600px; background: lightgrey}
+    </style>
+  </head>
+  <body>
+    <div class="test">
+      <p>The licenses for most software and other practical works are
+      designed to take away your freedom to share and change the works.
+      By contrast, the GNU General Public License is intended to
+      guarantee your freedom to share and change all versions of a
+      program--to make sure it remains free software for all its users.
+      We, the Free Software Foundation, use the GNU General Public
+      License for most of our software; it applies also to any other
+      work released this way by its authors. You can apply it to your
+      programs, too.</p>
+    </div>
+  </body>
+</html>

--- a/test/html/render/max-width-html.html
+++ b/test/html/render/max-width-html.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test max-width in html tag</title>
+    <style>
+      html {max-width: 400px}
+      body {margin: 20px}
+    </style>
+  </head>
+  <body>
+    <div>
+      <p>The licenses for most software and other practical works are
+      designed to take away your freedom to share and change the works.
+      By contrast, the GNU General Public License is intended to
+      guarantee your freedom to share and change all versions of a
+      program--to make sure it remains free software for all its users.
+      We, the Free Software Foundation, use the GNU General Public
+      License for most of our software; it applies also to any other
+      work released this way by its authors. You can apply it to your
+      programs, too.</p>
+    </div>
+  </body>
+</html>

--- a/test/html/render/max-width-html.ref.html
+++ b/test/html/render/max-width-html.ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test max-width in html tag</title>
+    <style>
+      div {width: 360px}
+      body {margin: 20px}
+    </style>
+  </head>
+  <body>
+    <div>
+      <p>The licenses for most software and other practical works are
+      designed to take away your freedom to share and change the works.
+      By contrast, the GNU General Public License is intended to
+      guarantee your freedom to share and change all versions of a
+      program--to make sure it remains free software for all its users.
+      We, the Free Software Foundation, use the GNU General Public
+      License for most of our software; it applies also to any other
+      work released this way by its authors. You can apply it to your
+      programs, too.</p>
+    </div>
+  </body>
+</html>

--- a/test/html/render/max-width-nested-div.html
+++ b/test/html/render/max-width-nested-div.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test max-width in a nested div</title>
+    <style>
+      body {margin: 20px}
+      .test {max-width: 400px; background: lightgray}
+    </style>
+  </head>
+  <body>
+    <div style="background:lightblue">
+      <div class="test">
+        <p>The licenses for most software and other practical works are
+        designed to take away your freedom to share and change the
+        works. By contrast, the GNU General Public License is intended
+        to guarantee your freedom to share and change all versions of a
+        program--to make sure it remains free software for all its
+        users. We, the Free Software Foundation, use the GNU General
+        Public License for most of our software; it applies also to any
+        other work released this way by its authors. You can apply it to
+        your programs, too.</p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/test/html/render/max-width-nested-div.ref.html
+++ b/test/html/render/max-width-nested-div.ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test max-width in a nested div</title>
+    <style>
+      body {margin: 20px}
+      .test {width: 400px; background: lightgray}
+    </style>
+  </head>
+  <body>
+    <div style="background:lightblue">
+      <div class="test">
+        <p>The licenses for most software and other practical works are
+        designed to take away your freedom to share and change the
+        works. By contrast, the GNU General Public License is intended
+        to guarantee your freedom to share and change all versions of a
+        program--to make sure it remains free software for all its
+        users. We, the Free Software Foundation, use the GNU General
+        Public License for most of our software; it applies also to any
+        other work released this way by its authors. You can apply it to
+        your programs, too.</p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/test/html/render/min-width-body.html
+++ b/test/html/render/min-width-body.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test min-width CSS property in the body</title>
+    <style>
+      body {min-width: 2000px; margin: 50px}
+      .test {background: lightgrey}
+    </style>
+  </head>
+  <body>
+    <div class="test">
+      <p>Hello</p>
+    </div>
+  </body>
+</html>

--- a/test/html/render/min-width-body.ref.html
+++ b/test/html/render/min-width-body.ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test min-width CSS property in the body</title>
+    <style>
+      body {margin: 50px}
+      .test {width: 2000px; background: lightgrey}
+    </style>
+  </head>
+  <body>
+    <div class="test">
+      <p>Hello</p>
+    </div>
+  </body>
+</html>

--- a/test/html/render/min-width-div.html
+++ b/test/html/render/min-width-div.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test min-width CSS property</title>
+    <style>
+      body {margin: 20px}
+      .test {min-width: 400px; display: inline-block; background: lightgrey}
+    </style>
+  </head>
+  <body>
+    <div class="test">
+      <p>Hello</p>
+    </div>
+  </body>
+</html>

--- a/test/html/render/min-width-div.ref.html
+++ b/test/html/render/min-width-div.ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test min-width CSS property</title>
+    <style>
+      body {margin: 20px}
+      .test {width: 400px; display: inline-block; background: lightgrey}
+    </style>
+  </head>
+  <body>
+    <div class="test">
+      <p>Hello</p>
+    </div>
+  </body>
+</html>

--- a/test/html/render/min-width-html.html
+++ b/test/html/render/min-width-html.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test min-width in the html tag</title>
+    <style>
+      html {min-width: 2000px}
+      body {margin: 0px}
+      .test {background: lightgrey}
+    </style>
+  </head>
+  <body>
+    <div class="test">
+      <p>Hello</p>
+    </div>
+  </body>
+</html>

--- a/test/html/render/min-width-html.ref.html
+++ b/test/html/render/min-width-html.ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test min-width in the html tag</title>
+    <style>
+      body {margin: 0px}
+      .test {width: 2000px; background: lightgrey}
+    </style>
+  </head>
+  <body>
+    <div class="test">
+      <p>Hello</p>
+    </div>
+  </body>
+</html>

--- a/test/html/render/min-width-nested-div.html
+++ b/test/html/render/min-width-nested-div.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test min-width CSS property</title>
+    <style>
+      body {margin: 20px}
+      .container {background: lightcyan}
+      .test {min-width: 400px; display: inline-block; background: lightgrey}
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="test">
+        <p>Hello</p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/test/html/render/min-width-nested-div.ref.html
+++ b/test/html/render/min-width-nested-div.ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test min-width CSS property</title>
+    <style>
+      body {margin: 20px}
+      .container {background: lightcyan}
+      .test {width: 400px; display: inline-block; background: lightgrey}
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="test">
+        <p>Hello</p>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
The calculation for the width was not taking into account the `min-width` and `max-width` attributes. Fixes #36.


https://github.com/dillo-browser/dillo/assets/3866127/5d5613f5-7023-4b92-b9a7-3e23d1a5ed00



I need to check that there is nothing else breaking, as there are no layout tests.