### PR TITLE
Free SSL connection before closing file descriptor

### DIFF
--- a/src/IO/http.c
+++ b/src/IO/http.c
@@ -2,6 +2,7 @@
  * File: http.c
  *
  * Copyright (C) 2000-2007 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -866,8 +867,11 @@ static void Http_socket_reuse(int SKey)
             return;
          }
       }
-      dClose(old_sd->SockFD);
+      /* Free the connection before closing the file descriptor, so more data
+       * can be written. */
+      int old_fd = old_sd->SockFD;
       Http_socket_free(SKey);
+      dClose(old_fd);
    }
 }
 

--- a/src/IO/tls_openssl.c
+++ b/src/IO/tls_openssl.c
@@ -1076,7 +1076,14 @@ static void Tls_connect(int fd, int connkey)
       return;
    }
 
-   assert(!ERR_get_error());
+   if (ERR_peek_error()) {
+      unsigned long err;
+      while ((err = ERR_get_error())) {
+         MSG("Tls_connect: queued error: %s\n",
+               ERR_error_string(err, NULL));
+      }
+      abort();
+   }
 
    ret = SSL_connect(conn->ssl);
 
@@ -1184,7 +1191,14 @@ void a_Tls_openssl_connect(int fd, const DilloUrl *url)
       success = FALSE;
    }
 
-   assert(!ERR_get_error());
+   if (ERR_peek_error()) {
+      unsigned long err;
+      while ((err = ERR_get_error())) {
+         MSG("a_Tls_openssl_connect: queued error: %s\n",
+               ERR_error_string(err, NULL));
+      }
+      abort();
+   }
 
    if (success && !(ssl = SSL_new(ssl_context))) {
       unsigned long err_ret = ERR_get_error();

--- a/src/IO/tls_openssl.c
+++ b/src/IO/tls_openssl.c
@@ -375,7 +375,8 @@ int a_Tls_openssl_connect_ready(const DilloUrl *url)
    Server_t *s;
    int ret = TLS_CONNECT_READY;
 
-   dReturn_val_if_fail(ssl_context, TLS_CONNECT_NEVER);
+   if (ssl_context == NULL)
+      return TLS_CONNECT_NEVER;
 
    if ((s = dList_find_sorted(servers, url, Tls_servers_by_url_cmp))) {
       if (s->cert_status == CERT_STATUS_RECEIVING)
@@ -580,7 +581,8 @@ static bool_t pattern_match (const char *pattern, const char *string)
 static bool_t Tls_check_cert_hostname(X509 *cert, const char *host,
                                       int *choice)
 {
-   dReturn_val_if_fail(cert && host, FALSE);
+   if (cert == NULL || host == NULL)
+      return FALSE;
 
    char *msg;
    GENERAL_NAMES *subjectAltNames;


### PR DESCRIPTION
Attempting to shutdown an SSL conection in LibreSSL was causing an error to be queued in the error queue, which was triggering the `assert(!ERR_get_error())` for a new connection. In OpenSSL this error was not queue in the "main" error queue, but only recorded for that SSL connection. so it was not triggering the assert.

The fix simply closes the file descriptor *after* performing the free operation.

@badsectoracula could you test this PR and check that fixes the #51 issue?

Fixes #51