### PR TITLE
Add ui_tab_height option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -52,6 +52,8 @@ dillo-3.1 [not released yet]
  - Add automatic rendering tests (only enabled with --enable-html-tests).
  - Fix width calculation when using 'min-width' and 'max-width'.
  - Update website URL to https://dillo-browser.github.io/
+ - Add ui_tab_height option to control the tab height. Default value increased
+   from 16 to 20 pixels to improve usability.
    Patches: Rodrigo Arias Mallo <rodarima@gmail.com>
 
 -----------------------------------------------------------------------------

--- a/dillorc
+++ b/dillorc
@@ -291,6 +291,8 @@ search_url="Google http://www.google.com/search?ie=UTF-8&oe=UTF-8&q=%s"
 # they are the main foreground color and the main background color,
 # respectively.
 #
+# ui_tab_height controls the height of the tabs (default 20).
+#
 # Note to packagers: leaving these variables for the system to guess
 # gives different results in different environments, so we played it safe
 # by defining the traditional colors.  Please choose the color theme that

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -2,6 +2,7 @@
  * Preferences
  *
  * Copyright (C) 2006-2009 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -114,6 +115,7 @@ void a_Prefs_init(void)
    prefs.ui_tab_active_bg_color = -1;
    prefs.ui_tab_bg_color = -1;
    prefs.ui_tab_active_fg_color = -1;
+   prefs.ui_tab_height = 20;
    prefs.ui_tab_fg_color = -1;
    prefs.ui_text_bg_color = -1;
 

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -2,6 +2,7 @@
  * Preferences
  *
  * Copyright (C) 2006-2009 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -58,6 +59,7 @@ typedef struct {
    int32_t ui_tab_active_fg_color;
    int32_t ui_tab_bg_color;
    int32_t ui_tab_fg_color;
+   int32_t ui_tab_height;
    int32_t ui_text_bg_color;
    bool_t contrast_visited_color;
    bool_t show_tooltip;

--- a/src/prefsparser.cc
+++ b/src/prefsparser.cc
@@ -2,6 +2,7 @@
  * Preferences parser
  *
  * Copyright (C) 2006-2009 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -222,6 +223,7 @@ void PrefsParser::parse(FILE *fp)
       { "ui_tab_bg_color", &prefs.ui_tab_bg_color, PREFS_COLOR, 0 },
       { "ui_tab_active_fg_color", &prefs.ui_tab_active_fg_color, PREFS_COLOR, 0 },
       { "ui_tab_fg_color", &prefs.ui_tab_fg_color, PREFS_COLOR, 0 },
+      { "ui_tab_height", &prefs.ui_tab_height, PREFS_INT32, 0 },
       { "ui_text_bg_color", &prefs.ui_text_bg_color, PREFS_COLOR, 0 },
       { "penalty_hyphen", &prefs.penalty_hyphen, PREFS_FRACTION_100, 0 },
       { "penalty_hyphen_2", &prefs.penalty_hyphen_2, PREFS_FRACTION_100, 0 },

--- a/src/uicmd.cc
+++ b/src/uicmd.cc
@@ -2,6 +2,7 @@
  * File: uicmd.cc
  *
  * Copyright (C) 2005-2011 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -550,7 +551,7 @@ BrowserWindow *a_UIcmd_browser_window_new(int ww, int wh,
       win = new Fl_Double_Window(ww, wh);
 
    win->box(FL_NO_BOX);
-   CustTabs *DilloTabs = new CustTabs(ww, wh, 16);
+   CustTabs *DilloTabs = new CustTabs(ww, wh, prefs.ui_tab_height);
    win->end();
    win->resizable(DilloTabs->wizard());
 


### PR DESCRIPTION
The default tab height of 16 pixels was causing some usability issues as the tabs are quite small in large monitors. The default size is increased to 20 pixels and the new option "ui_tab_height" allows the user to specify a different value.