### PR TITLE
Handle errors in SSL_read() and SSL_write()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -56,6 +56,7 @@ dillo-3.1 [not released yet]
    from 16 to 20 pixels to improve usability.
  - Switch tabs using the mouse wheel by default. Use the new option
    scroll_switches_tabs to disable the behavior.
+ - Fix OpenSSL handling of unexpected EOF without close notify alert.
    Patches: Rodrigo Arias Mallo <rodarima@gmail.com>
 
 -----------------------------------------------------------------------------


### PR DESCRIPTION
We cannot rely on the return value and the errno, the function SSL_get_error() must be used to determine what happen and if we need to retry again. A wrapper function translates the SSL error into a proper errno value.

In the case a premature EOF is sent by the server, the error queue is emptied before the error is returned.

Fixes: https://github.com/dillo-browser/dillo/issues/79