### PR TITLE
Expand tilde to home directory in local URLs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -57,6 +57,7 @@ dillo-3.1 [not released yet]
  - Switch tabs using the mouse wheel by default. Use the new option
    scroll_switches_tabs to disable the behavior.
  - Fix OpenSSL handling of unexpected EOF without close notify alert.
+ - Expand home tilde '~' in the file plugin.
    Patches: Rodrigo Arias Mallo <rodarima@gmail.com>
 
 -----------------------------------------------------------------------------

--- a/src/uicmd.cc
+++ b/src/uicmd.cc
@@ -730,8 +730,6 @@ void a_UIcmd_open_urlstr(void *vbw, const char *urlstr)
          ch = new_urlstr[5];
          if (!ch || ch == '.') {
             url = a_Url_new(Paths::getOldWorkingDir(), "file:");
-         } else if (ch == '~') {
-            url = a_Url_new(dGethomedir(), "file:");
          } else {
             url = a_Url_new(new_urlstr, "file:");
          }


### PR DESCRIPTION
Allows paths like `file:~/` and `file:~/.dillo/dillorc` to be opened by Dillo by expanding the tilde character `~` to the value of the `$HOME` environment variable.

Fixes: https://github.com/dillo-browser/dillo/issues/81