### PR TITLE
Ignore td relative width attribute

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -58,6 +58,7 @@ dillo-3.1 [not released yet]
    scroll_switches_tabs to disable the behavior.
  - Fix OpenSSL handling of unexpected EOF without close notify alert.
  - Expand home tilde '~' in the file plugin.
+ - Ignore width attribute with relative values for td and th elements.
    Patches: Rodrigo Arias Mallo <rodarima@gmail.com>
 
 -----------------------------------------------------------------------------

--- a/test/html/Makefile.am
+++ b/test/html/Makefile.am
@@ -32,5 +32,4 @@ XFAIL_TESTS = \
 	render/max-width-html.html \
 	render/min-width-html.html \
 	render/span-padding.html \
-	render/table-td-width-percent-img.html \
 	render/table-td-width-percent.html

--- a/test/html/Makefile.am
+++ b/test/html/Makefile.am
@@ -19,6 +19,7 @@ TESTS = \
 	render/min-width-html.html \
 	render/min-width-nested-div.html \
 	render/span-padding.html \
+	render/table-td-width-percent-img.html \
 	render/table-td-width-percent.html \
 	render/table-thead-tfoot.html \
 	render/white-space.html
@@ -31,4 +32,5 @@ XFAIL_TESTS = \
 	render/max-width-html.html \
 	render/min-width-html.html \
 	render/span-padding.html \
+	render/table-td-width-percent-img.html \
 	render/table-td-width-percent.html

--- a/test/html/Makefile.am
+++ b/test/html/Makefile.am
@@ -19,6 +19,7 @@ TESTS = \
 	render/min-width-html.html \
 	render/min-width-nested-div.html \
 	render/span-padding.html \
+	render/table-td-width-percent.html \
 	render/table-thead-tfoot.html \
 	render/white-space.html
 
@@ -29,4 +30,5 @@ XFAIL_TESTS = \
 	render/margin-auto.html \
 	render/max-width-html.html \
 	render/min-width-html.html \
-	render/span-padding.html
+	render/span-padding.html \
+	render/table-td-width-percent.html

--- a/test/html/render/table-td-width-percent-img.html
+++ b/test/html/render/table-td-width-percent-img.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
+<html>
+  <body>
+    <table>
+      <tr>
+        <td width="128" style="background: lightblue">
+          The next cell is 50%
+        </td>
+        <td width="50%" style="background: lightgreen">
+          <div>
+            <img src="pic.png">
+          </div>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/test/html/render/table-td-width-percent-img.ref.html
+++ b/test/html/render/table-td-width-percent-img.ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
+<html>
+  <body>
+    <table>
+      <tr>
+        <td width="128" style="background: lightblue">
+          The next cell is 50%
+        </td>
+        <td style="background: lightgreen">
+          <div>
+            <img src="pic.png">
+          </div>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/test/html/render/table-td-width-percent.html
+++ b/test/html/render/table-td-width-percent.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
+<html>
+  <head>
+    <title>Test relative width column</title>
+    <style type="text/css">
+      body { margin: 0px; padding: 0px }
+      .first { background: lightblue;  }
+      .second { background: lightgreen }
+      td, img { margin: 0px; padding: 0px; border: solid 1px black }
+    </style>
+  </head>
+  <body>
+    <table>
+      <tr>
+        <td width="300" class="first">
+          The next cell should have a 50% width of the table width.
+        </td>
+        <td width="25%" class="second">
+          This text should use the whole cell width, but for some reason is not
+          doing it?
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/test/html/render/table-td-width-percent.ref.html
+++ b/test/html/render/table-td-width-percent.ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
+<html>
+  <head>
+    <title>Test relative width column</title>
+    <style type="text/css">
+      body { margin: 0px; padding: 0px }
+      .first { background: lightblue;  }
+      .second { background: lightgreen }
+      td, img { margin: 0px; padding: 0px; border: solid 1px black }
+    </style>
+  </head>
+  <body>
+    <table>
+      <tr>
+        <td width="300" class="first">
+          The next cell should have a 50% width of the table width.
+        </td>
+        <td width="100" class="second">
+          This text should use the whole cell width, but for some reason is not
+          doing it?
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
Fixes #84, #54 

Before:
![kk](https://github.com/dillo-browser/dillo/assets/3866127/3a9b4199-655f-4bc5-9afa-49333856e324)

After:
![kk](https://github.com/dillo-browser/dillo/assets/3866127/0c90dc71-4c26-4c2c-9bf3-4d7e6e0dc9d3)

See the date in the top right corner being cut:
![kk](https://github.com/dillo-browser/dillo/assets/3866127/819d7d3e-7c96-49ff-a623-0e17e53fe77c)

Which is now visible:
![kk](https://github.com/dillo-browser/dillo/assets/3866127/9af530f9-cbfd-442d-ae51-621ec1b5934b)
