### PR TITLE
Add windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,3 +178,25 @@ jobs:
           make
           make check
           ldd src/dillo
+  windows-mbedtls:
+    needs: ubuntu-latest-html-tests
+    runs-on: windows-latest
+    steps:
+    - run: git config --global core.autocrlf input
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - uses: cygwin/cygwin-install-action@master
+      with:
+        packages: gcc-core gcc-g++ autoconf automake make zlib-devel mbedtls-devel libfltk-devel libiconv-devel libpng-devel libjpeg-devel libgif-devel
+    - shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+      run: |
+        set -x
+        cd ${GITHUB_WORKSPACE}
+        pwd
+        ls -l
+        ./autogen.sh
+        ./configure
+        make
+        make check
+        ls -l src/dillo

--- a/ChangeLog
+++ b/ChangeLog
@@ -60,6 +60,7 @@ dillo-3.1 [not released yet]
  - Expand home tilde '~' in the file plugin.
  - Ignore width attribute with relative values for td and th elements.
  - Enable Doxygen for C files and use Awesome Doxygen theme.
+ - Fix DPIs extension (.dpi.exe) in Windows systems via Cygwin.
    Patches: Rodrigo Arias Mallo <rodarima@gmail.com>
 
 -----------------------------------------------------------------------------

--- a/doc/install.md
+++ b/doc/install.md
@@ -43,7 +43,7 @@ $ sudo make install-strip
 ### From git
 
 ```sh
-$ git clone git@github.com:dillo-browser/dillo.git
+$ git clone https://github.com/dillo-browser/dillo.git
 $ cd dillo
 $ ./autogen.sh
 $ ./configure
@@ -127,4 +127,56 @@ For OpenSSL you can use either 1.1 or 3.X (recommended):
 ```
 $ brew install openssl@1.1
 $ brew install openssl@3
+```
+
+## Windows via Cygwin
+
+Dillo can be built for Windows (tested on Windows 11) by using the
+[Cygwin](https://www.cygwin.com/) POSIX portability layer and run with Xorg. You
+will need the following dependencies to build Dillo (with mbedTLS):
+
+```
+gcc-core gcc-g++ autoconf automake make zlib-devel mbedtls-devel libfltk-devel
+libiconv-devel libpng-devel libjpeg-devel libgif-devel
+```
+
+You will also need [Xorg](https://x.cygwin.com/docs/ug/cygwin-x-ug.html) to run
+Dillo graphically:
+
+```
+xorg-server xinit
+```
+
+You can also install all the dependencies from the command line with:
+```
+setup-x86_64.exe -q -P gcc-core,gcc-g++,autoconf,automake,make,zlib-devel,mbedtls-devel,libfltk-devel,libiconv-devel,libpng-devel,libjpeg-devel,libgif-devel,xorg-server,xinit
+```
+
+To build Dillo, follow the usual steps from a Cygwin shell:
+
+```sh
+$ git clone https://github.com/dillo-browser/dillo.git
+$ cd dillo
+$ ./autogen.sh
+$ mkdir build
+$ cd build
+$ ../configure --prefix=/usr/local
+$ make
+$ make install
+```
+
+You should be able to find Dillo in the `$PATH` as it should be installed in
+`/usr/local/bin/dillo`. To run it, you first need to have an [Xorg server
+running](https://x.cygwin.com/docs/ug/using.html#using-starting), which you can
+do from a shell:
+
+```sh
+$ startxwin
+```
+
+And then, from another shell:
+
+```sh
+$ export DISPLAY=:0
+$ dillo
 ```

--- a/dpid/Makefile.am
+++ b/dpid/Makefile.am
@@ -1,5 +1,6 @@
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
+	-DEXEEXT='"$(EXEEXT)"' \
 	-DDPIDRC_SYS='"$(sysconfdir)/dpidrc"'
 
 bin_PROGRAMS = dpid dpidc
@@ -31,5 +32,5 @@ sysconf_DATA = dpidrc
 CLEANFILES = $(sysconf_DATA)
 
 dpidrc: $(srcdir)/dpidrc.in Makefile
-	sed -e 's|[@]libdir[@]|$(libdir)|' $(srcdir)/dpidrc.in > dpidrc
+	sed -e 's|[@]libdir[@]|$(libdir)|;s|[@]EXEEXT[@]|$(EXEEXT)|g' $(srcdir)/dpidrc.in > dpidrc
 

--- a/dpid/dpid.c
+++ b/dpid/dpid.c
@@ -36,6 +36,8 @@
 
 #include "../dpip/dpip.h"
 
+#define DPI_EXT (".dpi" EXEEXT)
+
 #define QUEUE 5
 
 volatile sig_atomic_t caught_sigchld = 0;
@@ -140,16 +142,26 @@ void est_dpi_terminator()
    }
 }
 
+static int ends_with(const char *str, const char *suffix)
+{
+   if (!str || !suffix)
+      return 0;
+   size_t lenstr = strlen(str);
+   size_t lensuffix = strlen(suffix);
+   if (lensuffix > lenstr)
+      return 0;
+   return strncmp(str + lenstr - lensuffix, suffix, lensuffix) == 0;
+}
+
 /*! Identify a given file
  * Currently there is only one file type associated with dpis.
  * More file types will be added as needed
  */
 enum file_type get_file_type(char *file_name)
 {
-   char *dot = strrchr(file_name, '.');
-
-   if (dot && !strcmp(dot, ".dpi"))
-      return DPI_FILE;             /* Any filename ending in ".dpi" */
+   if (ends_with(file_name, DPI_EXT))
+      /* Any filename ending in ".dpi" (or ".dpi.exe" on Windows) */
+      return DPI_FILE;
    else {
       MSG_ERR("get_file_type: Unknown file type for %s\n", file_name);
       return UNKNOWN_FILE;

--- a/dpid/dpid_common.h
+++ b/dpid/dpid_common.h
@@ -35,10 +35,6 @@
 #define CKD_WRITE(fd, msg) ckd_write(fd, msg, __FILE__, __LINE__)
 #define CKD_CLOSE(fd)      ckd_close(fd, __FILE__, __LINE__)
 
-/*! Error codes for dpid */
-//fix for gcc 10
-extern enum  dpi_errno;
-
 /*! Intended for identifying dillo plugins
  * and related files
  */

--- a/dpid/dpidrc.in
+++ b/dpid/dpidrc.in
@@ -1,5 +1,5 @@
 dpi_dir=@libdir@/dillo/dpi
 
-proto.file=file/file.dpi
-proto.ftp=ftp/ftp.filter.dpi
-proto.data=datauri/datauri.filter.dpi
+proto.file=file/file.dpi@EXEEXT@
+proto.ftp=ftp/ftp.filter.dpi@EXEEXT@
+proto.data=datauri/datauri.filter.dpi@EXEEXT@


### PR DESCRIPTION
Add a Windows build to the CI using Cygwin and add the build process in the documentation. A small fix is also needed to let the DPI daemon find the DPI plugins when they have the ".dpi.exe" extension.