### PR TITLE
Add support for the main HTML tag

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -61,6 +61,7 @@ dillo-3.1 [not released yet]
  - Ignore width attribute with relative values for td and th elements.
  - Enable Doxygen for C files and use Awesome Doxygen theme.
  - Fix DPIs extension (.dpi.exe) in Windows systems via Cygwin.
+ - Add support for the <main> HTML tag.
    Patches: Rodrigo Arias Mallo <rodarima@gmail.com>
 
 -----------------------------------------------------------------------------

--- a/src/html.cc
+++ b/src/html.cc
@@ -2,6 +2,7 @@
  * File: html.cc
  *
  * Copyright (C) 2005-2007 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -3503,6 +3504,7 @@ static const TagInfo Tags[] = {
  /* legend 01?? */
  {"li", B8(01110),'O', Html_tag_open_li, NULL, Html_tag_close_li},
  {"link", B8(10001),'F', Html_tag_open_link, NULL, NULL},
+ {"main", B8(01110),'R', Html_tag_open_sectioning, NULL, NULL},
  {"map", B8(01101),'R', Html_tag_open_default, Html_tag_content_map,
                         Html_tag_close_map},
  {"mark", B8(01011),'R', Html_tag_open_default, NULL, NULL},

--- a/src/styleengine.cc
+++ b/src/styleengine.cc
@@ -2,6 +2,7 @@
  * File: styleengine.cc
  *
  * Copyright 2008-2009 Johannes Hofmann <Johannes.Hofmann@gmx.de>
+ * Copyright 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -997,7 +998,7 @@ void StyleEngine::init () {
       ":visited {color: #800080; text-decoration: underline; cursor: pointer}"
       "h1, h2, h3, h4, h5, h6, b, strong {font-weight: bolder}"
       "address, article, aside, center, div, figure, figcaption, footer,"
-      " h1, h2, h3, h4, h5, h6, header, nav, ol, p, pre, section, ul"
+      " h1, h2, h3, h4, h5, h6, header, main, nav, ol, p, pre, section, ul"
       " {display: block}"
       "i, em, cite, address, var {font-style: italic}"
       ":link img, :visited img {border: 1px solid}"

--- a/test/html/Makefile.am
+++ b/test/html/Makefile.am
@@ -11,6 +11,7 @@ TESTS = \
 	render/float-img-justify.html \
 	render/hackernews.html \
 	render/img-aspect-ratio.html \
+	render/main-style.html \
 	render/margin-auto.html \
 	render/max-width-body.html \
 	render/max-width-div.html \

--- a/test/html/render/main-style.html
+++ b/test/html/render/main-style.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Main should behave like a div</title>
+  </head>
+  <body>
+    <div style="margin-left: 20em; background: lightgreen">
+      div
+    </div>
+    <main style="margin-left: 20em; background: lightgreen">
+      main
+    </main>
+    <header style="margin-left: 20em; background: lightgreen">
+      header
+    </header>
+    <footer style="margin-left: 20em; background: lightgreen">
+      footer
+    </footer>
+  </body>
+</html>

--- a/test/html/render/main-style.ref.html
+++ b/test/html/render/main-style.ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Main should behave like a div</title>
+  </head>
+  <body>
+    <div style="margin-left: 20em; background: lightgreen">
+      div
+    </div>
+    <div style="margin-left: 20em; background: lightgreen">
+      main
+    </div>
+    <div style="margin-left: 20em; background: lightgreen">
+      header
+    </div>
+    <div style="margin-left: 20em; background: lightgreen">
+      footer
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Fixes: https://github.com/dillo-browser/dillo/issues/109

This was also affecting some pages that depended on styles applied to the `main` tag.

## Before
![1](https://github.com/dillo-browser/dillo/assets/3866127/cd299ff3-1da7-4360-a145-d9308fcb2dd7)

## After
![2](https://github.com/dillo-browser/dillo/assets/3866127/412bbbeb-270e-4e0b-b752-53d95fab4b9e)
