### PR TITLE
Control the direction of tab scrolling

### DIFF
--- a/dillorc
+++ b/dillorc
@@ -384,6 +384,9 @@ ui_tab_bg_color=#b7beb7
 # If set to NO, the page will be scrolled instead.
 #scroll_switches_tabs=YES
 
+# Reverse the direction of tab scrolling with mouse wheel.
+#scroll_switches_tabs_reverse=NO
+
 # Mouse middle click by default drives drag-scrolling.
 # To paste an URL into the window instead of scrolling, set it to NO.
 # Note: You could always paste the URL onto the URL box clear button.

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -79,6 +79,7 @@ void a_Prefs_init(void)
    prefs.middle_click_opens_new_tab = TRUE;
    prefs.right_click_closes_tab = TRUE;
    prefs.scroll_switches_tabs = TRUE;
+   prefs.scroll_switches_tabs_reverse = FALSE;
    prefs.no_proxy = dStrdup(PREFS_NO_PROXY);
    prefs.panel_size = P_medium;
    prefs.parse_embedded_css=TRUE;

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -107,6 +107,7 @@ typedef struct {
    bool_t middle_click_opens_new_tab;
    bool_t right_click_closes_tab;
    bool_t scroll_switches_tabs;
+   bool_t scroll_switches_tabs_reverse;
    bool_t search_url_idx;
    Dlist *search_urls;
    char *save_dir;

--- a/src/prefsparser.cc
+++ b/src/prefsparser.cc
@@ -192,6 +192,7 @@ void PrefsParser::parse(FILE *fp)
         PREFS_BOOL, 0 },
       { "right_click_closes_tab", &prefs.right_click_closes_tab, PREFS_BOOL, 0 },
       { "scroll_switches_tabs", &prefs.scroll_switches_tabs, PREFS_BOOL, 0 },
+      { "scroll_switches_tabs_reverse", &prefs.scroll_switches_tabs_reverse, PREFS_BOOL, 0 },
       { "no_proxy", &prefs.no_proxy, PREFS_STRING, 0 },
       { "panel_size", &prefs.panel_size, PREFS_PANEL_SIZE, 0 },
       { "parse_embedded_css", &prefs.parse_embedded_css, PREFS_BOOL, 0 },

--- a/src/uicmd.cc
+++ b/src/uicmd.cc
@@ -254,6 +254,9 @@ int CustTabs::handle(int e)
       int dy = Fl::event_dy();
       int dir = dy ? dy : dx;
 
+      if (prefs.scroll_switches_tabs_reverse)
+         dir = -dir;
+
       if (dir > 0)
          next_tab();
       else if (dir < 0)


### PR DESCRIPTION
Adds the `scroll_switches_tabs_reverse` option in dillorc to allows reversing the direction of tab switching based on the movement of the mouse wheel.

Fixes: #122 
See: https://lists.mailman3.com/hyperkitty/list/dillo-dev@mailman3.com/thread/F2EF4NHF3CBMJ3XZII2TFIE6MSXEE5AD/