### PR TITLE
Remove libgif dependency from docs

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -34,7 +34,7 @@ packages to build Dillo:
 ```sh
 $ sudo apt install gcc g++ autoconf automake make zlib1g-dev \
     libfltk1.3-dev libssl-dev libc6-dev \
-    libpng-dev libjpeg-dev libgif-dev
+    libpng-dev libjpeg-dev
 ```
 
 If you prefer to use mbedTLS, replace `libssl-dev` with
@@ -153,7 +153,7 @@ will need the following dependencies to build Dillo (with mbedTLS):
 
 ```
 gcc-core gcc-g++ autoconf automake make zlib-devel mbedtls-devel libfltk-devel
-libiconv-devel libpng-devel libjpeg-devel libgif-devel
+libiconv-devel libpng-devel libjpeg-devel
 ```
 
 You will also need [Xorg](https://x.cygwin.com/docs/ug/cygwin-x-ug.html) to run
@@ -165,7 +165,7 @@ xorg-server xinit
 
 You can also install all the dependencies from the command line with:
 ```
-setup-x86_64.exe -q -P gcc-core,gcc-g++,autoconf,automake,make,zlib-devel,mbedtls-devel,libfltk-devel,libiconv-devel,libpng-devel,libjpeg-devel,libgif-devel,xorg-server,xinit
+setup-x86_64.exe -q -P gcc-core,gcc-g++,autoconf,automake,make,zlib-devel,mbedtls-devel,libfltk-devel,libiconv-devel,libpng-devel,libjpeg-devel,xorg-server,xinit
 ```
 
 To build Dillo, follow the usual steps from a Cygwin shell:


### PR DESCRIPTION
The libgif library is not needed as Dillo has a builtin GIF support.

Fixes: https://github.com/dillo-browser/dillo/issues/128
Reported-by: dogma