### PR TITLE
Use DejaVu Sans for cursive by default

### DIFF
--- a/dillorc
+++ b/dillorc
@@ -54,7 +54,7 @@
 # "fc-list : family | cut -d ',' -f 2 | sort").
 #font_serif="DejaVu Serif"
 #font_sans_serif="DejaVu Sans"
-#font_cursive="URW Chancery L"
+#font_cursive="DejaVu Sans"
 #font_fantasy="DejaVu Sans"
 #font_monospace="DejaVu Sans Mono"
 #

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -16,7 +16,7 @@
 #define PREFS_HOME            "https://dillo-browser.github.io/"
 #define PREFS_FONT_SERIF      "DejaVu Serif"
 #define PREFS_FONT_SANS_SERIF "DejaVu Sans"
-#define PREFS_FONT_CURSIVE    "URW Chancery L"
+#define PREFS_FONT_CURSIVE    "DejaVu Sans"
 #define PREFS_FONT_FANTASY    "DejaVu Sans" /* TODO: find good default */
 #define PREFS_FONT_MONOSPACE  "DejaVu Sans Mono"
 #define PREFS_SEARCH_URL      "dd http://duckduckgo.com/lite/?kp=-1&kd=-1&q=%s"


### PR DESCRIPTION
The URW Chancery L font is not likely to be installed, so by default we use the same as for serif and sans, DejaVu.

Fixes: https://github.com/dillo-browser/dillo/issues/138