### PR TITLE
Improve quirk for text/xhtml content type

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -65,6 +65,7 @@ dillo-3.1 [not released yet]
  - Fix W3C validator and remove broken WDG validator.
  - Simplify bookmark DPI page style and improve readability.
  - Improve the Dillo manual available from the help button.
+ - Improve detection of XHTML documents
    Patches: Rodrigo Arias Mallo <rodarima@gmail.com>
 
 -----------------------------------------------------------------------------

--- a/dpi/file.c
+++ b/dpi/file.c
@@ -511,6 +511,7 @@ static const char *File_ext(const char *filename)
    } else if (!dStrAsciiCasecmp(e, "png")) {
       return "image/png";
    } else if (!dStrAsciiCasecmp(e, "html") ||
+              !dStrAsciiCasecmp(e, "xhtml") ||
               !dStrAsciiCasecmp(e, "htm") ||
               !dStrAsciiCasecmp(e, "shtml")) {
       return "text/html";

--- a/src/cache.c
+++ b/src/cache.c
@@ -2,6 +2,7 @@
  * File: cache.c
  *
  * Copyright 2000-2007 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -521,7 +522,12 @@ const char *a_Cache_set_content_type(const DilloUrl *url, const char *ctype,
          } else if (*from == 'm' &&
                     !dStrnAsciiCasecmp(ctype, "text/xhtml", 10)) {
             /* WORKAROUND: doxygen uses "text/xhtml" in META */
-            entry->TypeNorm = dStrdup(entry->TypeDet);
+            if (charset) {
+               entry->TypeNorm = dStrconcat("application/xhtml+xml",
+                        "; charset=", charset, NULL);
+            } else {
+               entry->TypeNorm = dStrdup("application/xhtml+xml");
+            }
          }
          if (charset) {
             if (entry->CharsetDecoder)


### PR DESCRIPTION
When a <meta> tag reports the "text/xhtml" content, we were correcting it to the type guessed in TypeDet. However, the current implementation to guess XHTML and HTML pages fails if the doctype is not at the start of the document, falling back to text/plain.

A more robust solution is to set the TypeNorm to "application/xhtml+xml", which can be handled by a_Mime_get_viewer() as an HTML-like document.

Fixes: https://lists.mailman3.com/hyperkitty/list/dillo-dev@mailman3.com/thread/7GJ4AAMFFPEHOIYEOH4NHVMSXMJDFYXG/