### PR TITLE
Implement force https mode.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   ubuntu-latest-html-tests:

--- a/ChangeLog
+++ b/ChangeLog
@@ -67,6 +67,8 @@ dillo-3.1 [not released yet]
  - Improve the Dillo manual available from the help button.
  - Improve detection of XHTML documents
    Patches: Rodrigo Arias Mallo <rodarima@gmail.com>
++- Add http_force_https mode.
+   Patches: Mark Walker
 
 -----------------------------------------------------------------------------
 

--- a/dillorc
+++ b/dillorc
@@ -195,6 +195,11 @@ search_url="Google http://www.google.com/search?ie=UTF-8&oe=UTF-8&q=%s"
 # HSTS directives are not saved between browser sessions.
 #http_strict_transport_security=YES
 
+# If enabled, Dillo will force all HTTP connections to be upgraded to
+# a more secure HTTPS connection. This will prevent sites from loading
+# if they only support HTTP.
+#http_force_https=NO
+
 # Set the proxy information for http/https.
 # Note that the http_proxy environment variable overrides this setting.
 # WARNING: FTP and downloads plugins use wget. To use a proxy with them,

--- a/src/menu.cc
+++ b/src/menu.cc
@@ -671,6 +671,19 @@ static void Menu_embedded_css_cb(Fl_Widget *wid, void*)
    a_UIcmd_repush(popup_bw);
 }
 
+
+/**
+ * Toggle use of force https mode
+ */
+static void Menu_force_https_cb(Fl_Widget *wid, void*)
+{
+   Fl_Menu_Item *item = (Fl_Menu_Item*) wid;
+
+   item->flags ^= FL_MENU_VALUE;
+   prefs.http_force_https = item->flags & FL_MENU_VALUE ? 1 : 0;
+   a_UIcmd_repush(popup_bw);
+}
+
 static void Menu_panel_change_cb(Fl_Widget*, void *user_data)
 {
    UI *ui = (UI*)popup_bw->ui;
@@ -728,6 +741,8 @@ void a_Menu_tools_popup(BrowserWindow *bw, int x, int y)
        FL_MENU_TOGGLE,0,0,0,0},
       {"Load background images", 0, Menu_bgimg_load_toggle_cb, 0,
        FL_MENU_TOGGLE|FL_MENU_DIVIDER,0,0,0,0},
+      {"Force HTTPS", 0, Menu_force_https_cb, 0,
+       FL_MENU_TOGGLE|FL_MENU_DIVIDER,0,0,0,0},
       {"Panel size", 0, Menu_nop_cb, (void*)"Submenu1", FL_SUBMENU,0,0,0,0},
          {"tiny",  0,Menu_panel_change_cb,(void*)0,FL_MENU_RADIO,0,0,0,0},
          {"small", 0,Menu_panel_change_cb,(void*)1,FL_MENU_RADIO,0,0,0,0},
@@ -751,8 +766,10 @@ void a_Menu_tools_popup(BrowserWindow *bw, int x, int y)
       pm[2].set();
    if (prefs.load_background_images)
       pm[3].set();
-   pm[5+cur_panelsize].setonly();
-   cur_smallicons ? pm[8].set() : pm[8].clear();
+   if (prefs.http_force_https)
+      pm[4].set();
+   pm[6+cur_panelsize].setonly();
+   cur_smallicons ? pm[9].set() : pm[9].clear();
 
    item = pm->popup(x, y);
    if (item) {

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -68,6 +68,7 @@ void a_Prefs_init(void)
    prefs.http_proxyuser = NULL;
    prefs.http_referer = dStrdup(PREFS_HTTP_REFERER);
    prefs.http_strict_transport_security = TRUE;
+   prefs.http_force_https = FALSE;
    prefs.http_user_agent = dStrdup(PREFS_HTTP_USER_AGENT);
    prefs.limit_text_width = FALSE;
    prefs.adjust_min_width = TRUE;

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -97,6 +97,7 @@ typedef struct {
    bool_t parse_embedded_css;
    bool_t http_persistent_conns;
    bool_t http_strict_transport_security;
+   bool_t http_force_https;
    int32_t buffered_drawing;
    char *font_serif;
    char *font_sans_serif;

--- a/src/prefsparser.cc
+++ b/src/prefsparser.cc
@@ -179,6 +179,7 @@ void PrefsParser::parse(FILE *fp)
       { "http_referer", &prefs.http_referer, PREFS_STRING, 0 },
       { "http_strict_transport_security",&prefs.http_strict_transport_security,
         PREFS_BOOL, 0 },
+      { "http_force_https", &prefs.http_force_https, PREFS_BOOL, 0 },
       { "http_user_agent", &prefs.http_user_agent, PREFS_STRING, 0 },
       { "limit_text_width", &prefs.limit_text_width, PREFS_BOOL, 0 },
       { "adjust_min_width", &prefs.adjust_min_width, PREFS_BOOL, 0 },


### PR DESCRIPTION
This pull request implements an option to force all http urls to be upgraded to https, similar to [HTTPS-Only Mode](https://support.mozilla.org/en-US/kb/https-only-prefs) in Firefox.

This is implemented by changing all http urls to https when they are created in a_Url_new.

A http_force_https preference is provided as well as a menu bar item to toggle this mode.