### PR TITLE
Move version to first paragraph of the manual

### DIFF
--- a/doc/user_help.in.html
+++ b/doc/user_help.in.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-  <title>Dillo __VERSION__ User Manual</title>
+  <title>Dillo User Manual</title>
     <style>
 body {
   background: white;
@@ -74,11 +74,11 @@ footer {
 
 <body>
 <div class="main">
-<h1>Dillo __VERSION__ User Manual</h1>
+<h1>Dillo User Manual</h1>
 
 <p>Welcome to the user manual of the Dillo browser. The manual is divided into
 <em>sections</em> but is written in a <em>single page</em> to allow search by
-keywords.</p>
+keywords. Generated for version __VERSION__.</p>
 
 <details><!-- Not supported in Dillo, but decays ok -->
 <summary class="toc">Table of contents:</summary>


### PR DESCRIPTION
When using "git describe" the resulting length of the version is too long for the header. As we only need to store the version somewhere in the manual, we place it at the end of the first paragraph.