### PR TITLE
Add custom new tab page

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -69,6 +69,7 @@ dillo-3.1 [not released yet]
  - Add version in user manual and about:splash.
    Patches: Rodrigo Arias Mallo <rodarima@gmail.com>
 +- Add http_force_https mode.
+ - Add new_tab_page option to load a custom page when opening a new tab.
    Patches: Mark Walker
 
 -----------------------------------------------------------------------------

--- a/dillorc
+++ b/dillorc
@@ -153,6 +153,11 @@
 # start_page="file:/home/jcid/custom_page.html"
 #start_page="about:splash"
 
+# Set the page that is opened when opening a new tab.
+# new_tab_page="dpi:/bm/"
+# new_tab_page="file:/home/jcid/new_tab_page.html"
+#new_tab_page="about:blank"
+
 # Set the home location
 # home="file:/home/jcid/HomePage/Home.html"
 #home="https://dillo-browser.github.io/"

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -13,6 +13,7 @@
 #include "prefs.h"
 
 #define PREFS_START_PAGE      "about:splash"
+#define PREFS_NEW_TAB_PAGE    "about:blank"
 #define PREFS_HOME            "https://dillo-browser.github.io/"
 #define PREFS_FONT_SERIF      "DejaVu Serif"
 #define PREFS_FONT_SANS_SERIF "DejaVu Sans"
@@ -110,6 +111,7 @@ void a_Prefs_init(void)
    prefs.show_ui_tooltip = TRUE;
    prefs.small_icons = FALSE;
    prefs.start_page = a_Url_new(PREFS_START_PAGE, NULL);
+   prefs.new_tab_page = a_Url_new(PREFS_NEW_TAB_PAGE, NULL);
    prefs.theme = dStrdup(PREFS_THEME);
    prefs.ui_button_highlight_color = -1;
    prefs.ui_fg_color = -1;

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -47,6 +47,7 @@ typedef struct {
    char *http_user_agent;
    char *no_proxy;
    DilloUrl *start_page;
+   DilloUrl *new_tab_page;
    DilloUrl *home;
    bool_t allow_white_bg;
    int32_t white_bg_replacement;

--- a/src/prefsparser.cc
+++ b/src/prefsparser.cc
@@ -221,6 +221,7 @@ void PrefsParser::parse(FILE *fp)
       { "show_ui_tooltip", &prefs.show_ui_tooltip, PREFS_BOOL, 0 },
       { "small_icons", &prefs.small_icons, PREFS_BOOL, 0 },
       { "start_page", &prefs.start_page, PREFS_URL, 0 },
+      { "new_tab_page", &prefs.new_tab_page, PREFS_URL, 0 },
       { "theme", &prefs.theme, PREFS_STRING, 0 },
       { "ui_button_highlight_color", &prefs.ui_button_highlight_color,
         PREFS_COLOR, 0 },

--- a/src/uicmd.cc
+++ b/src/uicmd.cc
@@ -230,7 +230,12 @@ int CustTabs::handle(int e)
          // Do nothing
          _MSG("CustTabs::handle KEYS_NOP\n");
       } else if (cmd == KEYS_NEW_TAB) {
-         a_UIcmd_open_url_nt(bw, NULL, 1);
+         if (dStrAsciiCasecmp(URL_SCHEME(prefs.new_tab_page), "about") == 0 &&
+             strcmp(URL_PATH(prefs.new_tab_page), "blank") == 0) {
+            a_UIcmd_open_url_nt(bw, NULL, 1);
+         } else {
+            a_UIcmd_open_url_nt(bw, prefs.new_tab_page, 1);
+         }
          ret = 1;
       } else if (cmd == KEYS_CLOSE_TAB) {
          a_UIcmd_close_bw(bw);


### PR DESCRIPTION
Adds the new_tab_page option which sets the page to be opened when opening a new tab.

Fixes: https://github.com/dillo-browser/dillo/issues/124