### PR TITLE
Disable "Layout::resizeIdle calls" message

### DIFF
--- a/dw/layout.cc
+++ b/dw/layout.cc
@@ -2,6 +2,7 @@
  * Dillo Widget
  *
  * Copyright 2005-2007 Sebastian Geerken <sgeerken@dillo.org>
+ * Copyright 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -873,7 +874,7 @@ void Layout::resizeIdle ()
    // Layout::queueResize(), where resizeIdleId is indeed checked.)
 
    while (resizeIdleId != -1) {
-      printf ("Layout::resizeIdle calls = %d\n", ++calls);
+      _MSG("Layout::resizeIdle calls = %d\n", ++calls);
 
       for (typed::Iterator <Widget> it = queueResizeList->iterator();
            it.hasNext (); ) {


### PR DESCRIPTION
It is always shown, even when messages are turned of by "show_msg=NO", as the preferences are not available to dw. For now we disable it permanently by using the _MSG() macro.

Reported-by: Kevin Koster <dillo@ombertech.com>
See: https://lists.mailman3.com/hyperkitty/list/dillo-dev@mailman3.com/message/PPNR5FTO3YFDVAQCM4SDNVAF22JEV22W/