### PR TITLE
Update online manual URL

### DIFF
--- a/src/ui.cc
+++ b/src/ui.cc
@@ -2,6 +2,7 @@
  * File: ui.cc
  *
  * Copyright (C) 2005-2007 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -248,7 +249,7 @@ static void help_cb(Fl_Widget *w, void *)
    } else {
       MSG("Can't read local help file at \"%s\"."
           " Getting remote help...\n", path);
-      a_UIcmd_open_urlstr(bw, "https://dillo-browser.github.io/old/dillo3-help.html");
+      a_UIcmd_open_urlstr(bw, "https://dillo-browser.github.io/user_help.html");
    }
    dFree(path);
 }


### PR DESCRIPTION
The old manual page is no longer needed as we have the latest manual rendered in the new website.