### PR TITLE
Disable TLSv1.3 in MbedTLS 3.6.0 for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,26 @@ jobs:
       run: make check
     - name: make distcheck
       run: make distcheck
+  alpine-mbedtls-3_6_0:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: jirutka/setup-alpine@v1
+      with:
+        packages: >
+          build-base
+          autoconf
+          automake
+          fltk-dev
+          libpng-dev
+          libjpeg-turbo-dev
+          mbedtls-dev
+    - run: |
+        ./autogen.sh
+        ./configure
+        make
+        make check
+      shell: alpine.sh {0}
   macOS-13-openssl-1-1:
     needs: ubuntu-latest-html-tests
     runs-on: macos-13

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,10 @@ Here we list changes that are relatively significant and/or visible to the
 user. For a history of changes in full detail, see our Git repository
 at https://github.com/dillo-browser/dillo
 
+dillo-3.1.1 [not released yet]
+
++- Disable TLSv1.3 in Mbed TLS 3.6.0 until it is supported.
+   Patches: Rodrigo Arias Mallo <rodarima@gmail.com>
 
 dillo-3.1.0 [May 4, 2024]
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -21,12 +21,13 @@ library to browse HTTPS pages. Currently, Dillo supports any of the
 following libraries:
 
  - OpenSSL 1.1 or 3
- - mbedTLS 2 or 3
+ - LibreSSL
+ - mbedTLS 2 or 3 (TLSv1.3 is not supported yet)
 
 If you don't want to use a TLS library, use the configure option
 `--disable-tls` to disable TLS support. You can use `--disable-openssl`
-and `--disable-mbedtls` to control the search. By default OpenSSL is
-search first, then mbedTLS.
+and `--disable-mbedtls` to control the search. By default OpenSSL or
+LibreSSL is search first, then mbedTLS.
 
 For Debian, you can use the following command to install the required
 packages to build Dillo:

--- a/src/IO/tls_mbedtls.c
+++ b/src/IO/tls_mbedtls.c
@@ -98,6 +98,12 @@ static Dlist *fd_map;
 
 static void Tls_handshake_cb(int fd, void *vconnkey);
 
+
+#if MBEDTLS_VERSION_NUMBER >= 0x03060000
+/* Moved to ssl_ciphersuites_internal.h in mbedtls 3.6.0 */
+int mbedtls_ssl_ciphersuite_uses_psk(const mbedtls_ssl_ciphersuite_t *info);
+#endif
+
 /*
  * Compare by FD.
  */
@@ -385,6 +391,15 @@ void a_Tls_mbedtls_init(void)
                                MBEDTLS_SSL_TRANSPORT_STREAM,
                                MBEDTLS_SSL_PRESET_DEFAULT);
    mbedtls_ssl_conf_cert_profile(&ssl_conf, &prof);
+
+   /*
+    * TLSv1.3 brings some changes, among them, having to call
+    * psa_crypto_init(), and a new way of resuming sessions,
+    * which is not currently supported by the code here.
+    */
+#if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+   mbedtls_ssl_conf_max_tls_version(&ssl_conf, MBEDTLS_SSL_VERSION_TLS1_2);
+#endif
 
    /*
     * There are security concerns surrounding session tickets --


### PR DESCRIPTION
In Mbed TLS 3.6.0 there is now support for TLSv1.3, but it requires special handling so for now we disable it.

See: https://gitlab.alpinelinux.org/alpine/aports/-/commit/4dc36afaa81a4d73758b29fa77981d07dbae0080.patch
Fixes: https://github.com/dillo-browser/dillo/issues/158