### PR TITLE
Update macOS dillo install instructions

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -130,6 +130,14 @@ at link time.
 
 ## MacOS
 
+Dillo is now packaged in [Homebrew](https://brew.sh/).
+
+```
+$ brew install dillo
+```
+
+### Building from source
+
 To build Dillo on MacOS you would need to get FLTK as well as
 autoconf and automake if you are building Dillo from the git repository.
 They are available in the Homebrew package manager:


### PR DESCRIPTION
Dillo is now packaged (bottled) in Homebrew as seen here - 
https://github.com/Homebrew/homebrew-core/blob/master/Formula/d/dillo.rb
