### PR TITLE
Avoid reaching into X509_ALGOR

### DIFF
--- a/src/IO/tls_openssl.c
+++ b/src/IO/tls_openssl.c
@@ -464,8 +464,9 @@ static bool_t Tls_check_cert_strength(SSL *ssl, Server_t *srv, int *choice)
           * then trim off the "With..." part.
           */
          b = BIO_new(BIO_s_mem());
-         const X509_ALGOR *sigalg = X509_get0_tbs_sigalg(cert);
-         rc = i2a_ASN1_OBJECT(b, sigalg->algorithm);
+         const ASN1_OBJECT *algorithm;
+         X509_ALGOR_get0(&algorithm, NULL, NULL, X509_get0_tbs_sigalg(cert));
+         rc = i2a_ASN1_OBJECT(b, algorithm);
 
          if (rc > 0) {
             rc = BIO_gets(b, buf, buflen);


### PR DESCRIPTION
It would be nice if X509_ALGOR could be made opaque at some point. There is a somewhat clumsy accessor X509_ALGOR_get0() that allows obtaining the ASN1_OBJECT sitting inside an X509_ALGOR. Use this instead.