### PR TITLE
Add workaround for OpenSSL in Cygwin

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ at https://github.com/dillo-browser/dillo
 dillo-3.1.1 [not released yet]
 
 +- Disable TLSv1.3 in Mbed TLS 3.6.0 until it is supported.
+ - Add workaround for Cygwin and OpenSSL with --disable-threaded-dns.
    Patches: Rodrigo Arias Mallo <rodarima@gmail.com>
 
 dillo-3.1.0 [May 4, 2024]

--- a/doc/install.md
+++ b/doc/install.md
@@ -166,12 +166,17 @@ $ ./configure LDFLAGS="-L`brew --prefix openssl`/lib" CPPFLAGS="-I`brew --prefix
 
 Dillo can be built for Windows (tested on Windows 11) by using the
 [Cygwin](https://www.cygwin.com/) POSIX portability layer and run with Xorg. You
-will need the following dependencies to build Dillo (with mbedTLS):
+will need the following dependencies to build Dillo with mbedTLS:
 
 ```
 gcc-core gcc-g++ autoconf automake make zlib-devel mbedtls-devel libfltk-devel
 libiconv-devel libpng-devel libjpeg-devel
 ```
+
+**Note**: Dillo can also be built with OpenSSL (libssl-devel) but there is a
+[known problem with detached threads](https://github.com/dillo-browser/dillo/issues/172)
+used by the DNS resolver and OpenSSL that causes a crash. If you use OpenSSL,
+disable the threaded resolver with `--disable-threaded-dns`.
 
 You will also need [Xorg](https://x.cygwin.com/docs/ug/cygwin-x-ug.html) to run
 Dillo graphically:


### PR DESCRIPTION
Cygwin doesn't seem to support detached threads used by the threaded DNS resolver at the same time the dynamic OpenSSL library is used. As a workaround we suggest disabling the threaded DNS (will use the same thread) if building with OpenSSL on Cygwin.

Fixes: https://github.com/dillo-browser/dillo/issues/172