### PR TITLE
Ensure the release tarball can run HTML rendering tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,13 @@ jobs:
     - name: autogen
       run: ./autogen.sh
     - name: Make install dir
-      run: mkdir install
+      run: mkdir install build
     - name: configure
-      run: ./configure --prefix=$(readlink -f install) --enable-html-tests
+      run: cd build && ../configure --prefix=$(readlink -f ../install) --enable-html-tests
     - name: make
-      run: make
+      run: cd build && make
     - name: make install
-      run: make install
+      run: cd build && make install
     - name: Copy config to .dillo
       run: |
         mkdir -p ~/.dillo/
@@ -29,12 +29,13 @@ jobs:
     - name: make check
       run: |
         export DILLOBIN=$(readlink -f install/bin/dillo)
-        make check || (cat test/html/test-suite.log; false)
+        cd build && make check || (cat test/html/test-suite.log; false)
     - name: make distcheck (with HTML tests)
       run: |
         export DILLOBIN=
-        export DISTCHECK_CONFIGURE_FLAGS=--enable-html-tests
-        make distcheck
+        mkdir build-distcheck install-distcheck
+        cd build-distcheck && ../configure --prefix=$(readlink -f ../install-distcheck) --enable-html-tests
+        make distcheck DISTCHECK_CONFIGURE_FLAGS=--enable-html-tests
 #   - name: Remove pipes
 #     run: find test/html -type p -delete || true
 #   - name: Archive production artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,11 @@ jobs:
       run: |
         export DILLOBIN=$(readlink -f install/bin/dillo)
         make check || (cat test/html/test-suite.log; false)
+    - name: make distcheck (with HTML tests)
+      run: |
+        export DILLOBIN=
+        export DISTCHECK_CONFIGURE_FLAGS=--enable-html-tests
+        make distcheck
 #   - name: Remove pipes
 #     run: find test/html -type p -delete || true
 #   - name: Archive production artifacts

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,7 +10,10 @@ dillo-3.1.1 [not released yet]
 
 +- Disable TLSv1.3 in Mbed TLS 3.6.0 until it is supported.
  - Add workaround for Cygwin and OpenSSL with --disable-threaded-dns.
+ - Fix distcheck when HTML tests are enabled.
    Patches: Rodrigo Arias Mallo <rodarima@gmail.com>
++- Add HTML tests to the distributed tarball.
+   Patches: Matt Jolly
 
 dillo-3.1.0 [May 4, 2024]
 

--- a/test/html/Makefile.am
+++ b/test/html/Makefile.am
@@ -5,6 +5,11 @@ AM_TESTS_ENVIRONMENT = env \
 
 LOG_COMPILER = $(srcdir)/driver.sh
 
+EXTRA_DIST = \
+	driver.sh \
+	manual \
+	render
+
 TESTS = \
 	render/b-div.html \
 	render/div-100-percent-with-padding.html \

--- a/test/html/driver.sh
+++ b/test/html/driver.sh
@@ -77,7 +77,7 @@ function test_file() {
   render_page "$ref_file" "$wdir/ref.png"
 
   # AE = Absolute Error count of the number of different pixels
-  diffcount=$(compare -metric AE "$wdir/html.png" "$wdir/ref.png" "$wdir/diff.png" 2>&1)
+  diffcount=$(compare -metric AE "$wdir/html.png" "$wdir/ref.png" "$wdir/diff.png" 2>&1 || true)
 
   # The test passes only if both images are identical
   if [ "$diffcount" = "0" ]; then


### PR DESCRIPTION
This is a continuation of https://github.com/dillo-browser/dillo/pull/176 as I accidentally closed it while trying to add a commit to test the CI, and prevented me from updating it further.

Original comment by @Kangie:
> This will enable tests to be easily run by downstream distributions.
> 
> These files are not included in the 3.1.0 release tarball, resulting in errors like:
> 
> ```
> make[4]: Entering directory '/var/tmp/portage/www-client/dillo-3.1.0/work/dillo-3.1.0/test/html'
> make[4]: *** No rule to make target 'render/b-div.html', needed by 'render/b-div.html.log'.  Stop
> ```
> 
> When distributions try to package and test the software.