### PR TITLE
Handle SSL_ERROR_ZERO_RETURN in OpenSSL

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,8 @@ dillo-3.1.1 [not released yet]
 +- Disable TLSv1.3 in Mbed TLS 3.6.0 until it is supported.
  - Add workaround for Cygwin and OpenSSL with --disable-threaded-dns.
  - Fix distcheck when HTML tests are enabled.
+ - Fix an OpenSSL bug when the server closes the connection prematurely and
+   SSL_get_error() returns SSL_ERROR_ZERO_RETURN.
    Patches: Rodrigo Arias Mallo <rodarima@gmail.com>
 +- Add HTML tests to the distributed tarball.
    Patches: Matt Jolly

--- a/src/IO/tls_openssl.c
+++ b/src/IO/tls_openssl.c
@@ -1277,6 +1277,9 @@ static int Tls_handle_error(Conn_t *conn, int ret, const char *where)
    if (err1_ret == SSL_ERROR_NONE) {
       errno = 0;
       return ret;
+   } else if (err1_ret == SSL_ERROR_ZERO_RETURN) {
+      errno = 0;
+      return 0;
    } else if (err1_ret == SSL_ERROR_WANT_READ || err1_ret == SSL_ERROR_WANT_WRITE) {
       errno = EAGAIN;
       return -1;

--- a/src/IO/tls_openssl.c
+++ b/src/IO/tls_openssl.c
@@ -1272,6 +1272,12 @@ void a_Tls_openssl_connect(int fd, const DilloUrl *url)
  */
 static int Tls_handle_error(Conn_t *conn, int ret, const char *where)
 {
+   /* Success */
+   if (ret > 0) {
+      errno = 0;
+      return ret;
+   }
+
    SSL *ssl = conn->ssl;
    int err1_ret = SSL_get_error(ssl, ret);
    if (err1_ret == SSL_ERROR_NONE) {


### PR DESCRIPTION
It may be returned when the server closes the connection, see:
https://www.openssl.org/docs/manmaster/man3/SSL_get_error.html

We simply handle it as if there was no error and return zero bytes read.

Fixes: https://github.com/dillo-browser/dillo/issues/175