### PR TITLE
Remove undefined floatRef debug line in RTFL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,7 +67,7 @@ AC_ARG_ENABLE([threaded-dns],
   [enable_threaded_dns=yes])
 
 AC_ARG_ENABLE([rtfl],
-  [AS_HELP_STRING([--enable-rtfl], [Build with RTFL messages (for debugging rendering)])],
+  [AS_HELP_STRING([--enable-rtfl], [Print low-level RTFL messages for debugging the renderer (very large slowdown)])],
   [enable_rtfl=$enableval],
   [enable_rtfl=no])
 

--- a/dw/ooffloatsmgr.cc
+++ b/dw/ooffloatsmgr.cc
@@ -2,6 +2,7 @@
  * Dillo Widget
  *
  * Copyright 2013-2014 Sebastian Geerken <sgeerken@dillo.org>
+ * Copyright 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -963,7 +964,6 @@ void OOFFloatsMgr::getSize (Requisition *cbReq, int *oofWidth, int *oofHeight)
       max (oofHeightLeft, oofHeightRight) + container->boxRestHeight ();
 
    SizeChanged = true;
-   DBG_OBJ_SET_NUM ("floatRef", floatRef);
 
    DBG_OBJ_MSGF ("resize.oofm", 1,
                  "=> (l: %d, r: %d => %d) * (l: %d, r: %d => %d)",


### PR DESCRIPTION
Fixes: https://bugs.gentoo.org/933361

CC @asarubbo @Kangie 

**Note:** The `--enable-rtfl` flag will cause *a lot* of printf lines which are used to debug the rendering engine (with another tool called RTFL). They are not recommended while browsing as a user as they will slowdown the browser a lot.