### PR TITLE
Ensure the same number of tags for CSS and HTML

### DIFF
--- a/src/css.hh
+++ b/src/css.hh
@@ -1,8 +1,21 @@
+/*
+ * File: css.hh
+ *
+ * Copyright (C) 2008-2014 Johannes Hofmann <Johannes.Hofmann@gmx.de>
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
 #ifndef __CSS_HH__
 #define __CSS_HH__
 
 #include "dw/core.hh"
 #include "doctree.hh"
+#include "html.hh"
 
 /* Origin and weight. Used only internally.*/
 typedef enum {
@@ -482,12 +495,7 @@ class CssStyleSheet {
                <lout::object::ConstString, RuleList > (true, true, 256) {};
       };
 
-      static const int ntags = 90 + 14; // \todo don't hardcode
-      /* 90 is the full number of html4 elements, including those which we have
-       * implemented. From html5, let's add: article, header, footer, mark,
-       * nav, section, aside, figure, figcaption, wbr, audio, video, source,
-       * embed.
-       */
+      static const int ntags = HTML_NTAGS;
 
       RuleList elementTable[ntags], anyTable;
       RuleMap idTable, classTable;

--- a/src/html.cc
+++ b/src/html.cc
@@ -3555,6 +3555,8 @@ static const TagInfo Tags[] = {
 };
 #define NTAGS (sizeof(Tags)/sizeof(Tags[0]))
 
+static_assert(NTAGS == HTML_NTAGS,
+   "Mismatch between number of tags in Tags and HTML_NTAGS");
 
 /*
  * Compares tag from buffer ('/' or '>' or space-ended string) [p1]

--- a/src/html.hh
+++ b/src/html.hh
@@ -1,3 +1,15 @@
+/*
+ * File: html.hh
+ *
+ * Copyright (C) 2005-2009 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
 #ifndef __HTML_HH__
 #define __HTML_HH__
 
@@ -6,6 +18,10 @@
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
+
+/* Keep in sync with the length of the Tags array. It is protected by an
+ * static assert in html.cc to prevent errors) */
+#define HTML_NTAGS 93
 
 /*
  * Exported functions


### PR DESCRIPTION
The Tags array can be modified without changing the "ntags" number in the CSS side. To prevent errors, an static assert ensures the same number is used in both sides, which is known at compilation time.

Fixes: https://github.com/dillo-browser/dillo/issues/184