### PR TITLE
Release version 3.1.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,7 +6,7 @@ Here we list changes that are relatively significant and/or visible to the
 user. For a history of changes in full detail, see our Git repository
 at https://github.com/dillo-browser/dillo
 
-dillo-3.1.1 [not released yet]
+dillo-3.1.1 [Jun 8, 2024]
 
 +- Disable TLSv1.3 in Mbed TLS 3.6.0 until it is supported.
  - Add workaround for Cygwin and OpenSSL with --disable-threaded-dns.

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Process this file with aclocal, autoconf and automake.
 
-AC_INIT([dillo], [3.1.0])
+AC_INIT([dillo], [3.1.1])
 
 dnl Detect the canonical target build environment
 AC_CANONICAL_TARGET


### PR DESCRIPTION
Closes milestone [3.1.1](https://github.com/dillo-browser/dillo/milestone/2)