### PR TITLE
Add new_tab_page option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,11 @@ Here we list changes that are relatively significant and/or visible to the
 user. For a history of changes in full detail, see our Git repository
 at https://github.com/dillo-browser/dillo
 
+dillo-3.2.0 [Not released yet]
+
++- Add new_tab_page option to open a custom new tab page.
+   Patches: Alex, Rodrigo Arias Mallo
+
 dillo-3.1.1 [Jun 8, 2024]
 
 +- Disable TLSv1.3 in Mbed TLS 3.6.0 until it is supported.

--- a/dillorc
+++ b/dillorc
@@ -157,6 +157,11 @@
 # home="file:/home/jcid/HomePage/Home.html"
 #home="https://dillo-browser.github.io/"
 
+# Set the new tab page.
+# new_tab_page="dpi:/bm/"
+# new_tab_page="https://example.com/"
+#new_tab_page="about:blank"
+
 # Set the URLs used by the web search dialog.
 # "%s" is replaced with the search keywords separated by '+'.
 # Format: search_url="[prefix ][<label> ]<url>"

--- a/doc/user_help.in.html
+++ b/doc/user_help.in.html
@@ -318,7 +318,8 @@ DuckDuckGo for the keywords "dillo browser".
 <p>
 Dillo can open different web pages into tabs. To open a link in a new tab click
 the middle button instead of the left button. The same applies to buttons to
-submit a form.
+submit a form. A new tab can also be opened from the <code>File</code> menu or
+using the shortcut <code>Ctrl+T</code>.
 <p>
 By default the new tab will be automatically focused. If you want to change
 this behaviour, adjust the following options in the 
@@ -336,6 +337,13 @@ tabs). You can also close the tab by clicking with the right button on the tab
 label. The middle button can be used instead by setting the option:
 <pre>
 right_click_closes_tab=NO
+</pre>
+<p>
+Use the <code>new_tab_page</code> option to control which page is loaded in a
+newly opened tab, by default is an empty page. To open the
+bookmarks page set the following line in <a href="#dillorc">dillorc</a>:
+<pre>
+new_tab_page="dpi:/bm/"
 </pre>
 
 <h3 id="bookmarks">Bookmarks</h3>

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -14,6 +14,7 @@
 
 #define PREFS_START_PAGE      "about:splash"
 #define PREFS_HOME            "https://dillo-browser.github.io/"
+#define PREFS_NEW_TAB_PAGE    "about:blank"
 #define PREFS_FONT_SERIF      "DejaVu Serif"
 #define PREFS_FONT_SANS_SERIF "DejaVu Sans"
 #define PREFS_FONT_CURSIVE    "DejaVu Sans"
@@ -110,6 +111,7 @@ void a_Prefs_init(void)
    prefs.show_ui_tooltip = TRUE;
    prefs.small_icons = FALSE;
    prefs.start_page = a_Url_new(PREFS_START_PAGE, NULL);
+   prefs.new_tab_page = a_Url_new(PREFS_NEW_TAB_PAGE, NULL);
    prefs.theme = dStrdup(PREFS_THEME);
    prefs.ui_button_highlight_color = -1;
    prefs.ui_fg_color = -1;
@@ -155,5 +157,6 @@ void a_Prefs_freeall(void)
       dFree(dList_nth_data(prefs.search_urls, i));
    dList_free(prefs.search_urls);
    a_Url_free(prefs.start_page);
+   a_Url_free(prefs.new_tab_page);
    dFree(prefs.theme);
 }

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -48,6 +48,7 @@ typedef struct {
    char *no_proxy;
    DilloUrl *start_page;
    DilloUrl *home;
+   DilloUrl *new_tab_page;
    bool_t allow_white_bg;
    int32_t white_bg_replacement;
    int32_t bg_color;

--- a/src/prefsparser.cc
+++ b/src/prefsparser.cc
@@ -171,6 +171,7 @@ void PrefsParser::parse(FILE *fp)
       { "fullwindow_start", &prefs.fullwindow_start, PREFS_BOOL, 0 },
       { "geometry", NULL, PREFS_GEOMETRY, 0 },
       { "home", &prefs.home, PREFS_URL, 0 },
+      { "new_tab_page", &prefs.new_tab_page, PREFS_URL, 0 },
       { "http_language", &prefs.http_language, PREFS_STRING, 0 },
       { "http_max_conns", &prefs.http_max_conns, PREFS_INT32, 0 },
       { "http_persistent_conns", &prefs.http_persistent_conns, PREFS_BOOL, 0 },

--- a/src/uicmd.cc
+++ b/src/uicmd.cc
@@ -770,6 +770,11 @@ void a_UIcmd_open_url(BrowserWindow *bw, const DilloUrl *url)
 
 static void UIcmd_open_url_nbw(BrowserWindow *new_bw, const DilloUrl *url)
 {
+   if (!url && prefs.new_tab_page) {
+      if (strcmp(URL_STR(prefs.new_tab_page), "about:blank") != 0)
+         url = prefs.new_tab_page;
+   }
+
    /* When opening a new BrowserWindow (tab or real window) we focus
     * Location if we don't yet have an URL, main otherwise.
     */

--- a/src/url.c
+++ b/src/url.c
@@ -2,6 +2,7 @@
  * File: url.c
  *
  * Copyright (C) 2001-2009 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -374,7 +375,9 @@ DilloUrl* a_Url_new(const char *url_str, const char *base_url)
    Dstr *SolvedUrl;
    int i, n_ic, n_ic_spc;
 
-   dReturn_val_if_fail (url_str != NULL, NULL);
+   /* NULL or empty URL is not valid */
+   if (!url_str || url_str[0] == '\0')
+      return NULL;
 
    /* Count illegal characters (0x00-0x1F, 0x7F-0xFF and space) */
    n_ic = n_ic_spc = 0;


### PR DESCRIPTION
Adds support to load a custom page when a new tab is opened. The current behavior is set as the default, load a blank page. The location bar is only selected when the new tab page is the blank page, otherwise the page loaded gets the focus.


Fixes: https://github.com/dillo-browser/dillo/issues/124