### PR TITLE
Allow empty URLs with base URL set

### DIFF
--- a/src/html.cc
+++ b/src/html.cc
@@ -172,11 +172,20 @@ DilloUrl *a_Html_url_new(DilloHtml *html,
                          const char *url_str, const char *base_url,
                          int use_base_url)
 {
-   DilloUrl *url;
-   int n_ic, n_ic_spc;
+   if (!url_str) {
+      MSG("a_Html_url_new: URL is NULL\n");
+      return NULL;
+   }
 
-   url = a_Url_new(url_str,
+   DilloUrl *url = a_Url_new(url_str,
                    (use_base_url) ? base_url : URL_STR_(html->base_url));
+
+   if (!url) {
+      BUG_MSG("URL is not valid '%s'.", url_str);
+      return NULL;
+   }
+
+   int n_ic, n_ic_spc;
    if ((n_ic = URL_ILLEGAL_CHARS(url)) != 0) {
       const char *suffix = (n_ic) > 1 ? "s" : "";
       n_ic_spc = URL_ILLEGAL_CHARS_SPC(url);

--- a/src/url.c
+++ b/src/url.c
@@ -375,8 +375,12 @@ DilloUrl* a_Url_new(const char *url_str, const char *base_url)
    Dstr *SolvedUrl;
    int i, n_ic, n_ic_spc;
 
-   /* NULL or empty URL is not valid */
-   if (!url_str || url_str[0] == '\0')
+   if (!url_str)
+      return NULL;
+
+   /* Empty URL without base_url is not valid.
+    * They are used for action="" in forms with base_url set. */
+   if (url_str[0] == '\0' && base_url == NULL)
       return NULL;
 
    /* Count illegal characters (0x00-0x1F, 0x7F-0xFF and space) */


### PR DESCRIPTION
They are used for href="" in links or action="" in forms.

Fixes: https://github.com/dillo-browser/dillo/issues/190