### PR TITLE
Ignore empty page title for tab labels

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,8 @@ dillo-3.2.0 [Not released yet]
 
 +- Add new_tab_page option to open a custom new tab page.
    Patches: Alex, Rodrigo Arias Mallo
++- Ignore empty page title for tab labels.
+   Patches: Rodrigo Arias Mallo
 
 dillo-3.1.1 [Jun 8, 2024]
 

--- a/src/html.cc
+++ b/src/html.cc
@@ -1706,10 +1706,14 @@ static void Html_tag_open_title(DilloHtml *html, const char *tag, int tagsize)
  */
 static void Html_tag_close_title(DilloHtml *html)
 {
+   /* title is only valid inside HEAD */
    if (html->InFlags & IN_HEAD && html->Num_TITLE == 1) {
-      /* title is only valid inside HEAD */
-      a_UIcmd_set_page_title(html->bw, html->Stash->str);
-      a_History_set_title_by_url(html->page_url, html->Stash->str);
+      /* Ignore empty titles: <title></title> */
+      char *title = html->Stash->str;
+      if (!title || title[0] == '\0')
+         return;
+      a_UIcmd_set_page_title(html->bw, title);
+      a_History_set_title_by_url(html->page_url, title);
    }
 }
 

--- a/test/html/manual/title-dup.html
+++ b/test/html/manual/title-dup.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>one</title>
+    <title>two</title>
+  </head>
+  <body>
+    <p>Duplicated title</p>
+  </body>
+</html>

--- a/test/html/manual/title-empty.html
+++ b/test/html/manual/title-empty.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title></title>
+  </head>
+  <body>
+    <p>Empty title</p>
+  </body>
+</html>

--- a/test/html/manual/title-missing.html
+++ b/test/html/manual/title-missing.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  </head>
+  <body>
+    <p>Missing title</p>
+  </body>
+</html>


### PR DESCRIPTION
When a page has an empty title like <title></title>, don't use it to set the tab label, but instead rely on the default tab label, which is computed from the file name.