### PR TITLE
Allow actions to be defined to handle URLs

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,6 +37,8 @@ dillo_SOURCES = \
 	bw.c \
 	cookies.c \
 	cookies.h \
+	rules.c \
+	rules.h \
 	hsts.c \
 	hsts.h \
 	auth.c \

--- a/src/dillo.cc
+++ b/src/dillo.cc
@@ -2,6 +2,7 @@
  * Dillo web browser
  *
  * Copyright 1999-2007 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -55,6 +56,7 @@
 #include "capi.h"
 #include "dicache.h"
 #include "cookies.h"
+#include "rules.h"
 #include "hsts.h"
 #include "domain.h"
 #include "auth.h"
@@ -474,6 +476,7 @@ int main(int argc, char **argv)
    a_Dicache_init();
    a_Bw_init();
    a_Cookies_init();
+   a_Rules_init();
    a_Hsts_init(Paths::getPrefsFP(PATHS_HSTS_PRELOAD));
    a_Auth_init();
    a_UIcmd_init();

--- a/src/rules.c
+++ b/src/rules.c
@@ -1,0 +1,185 @@
+/*
+ * File: rules.c
+ *
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "rules.h"
+#include "msg.h"
+#include "../dlib/dlib.h"
+#include <stdio.h>
+#include <errno.h>
+
+#define LINE_MAXLEN 4096
+
+static struct rules rules;
+
+int
+parse_string(char *line, char *buf, int n, char **next)
+{
+   char *p = line;
+   if (*p != '"') {
+      MSG("expecting string\n");
+      return -1;
+   }
+
+   p++; /* Skip quote */
+
+   int i = 0;
+   while (1) {
+      if (p[0] == '\\' && p[1] == '"') {
+         if (i >= n) {
+            MSG("too big\n");
+            return -1;
+         }
+         buf[i++] = '"';
+         p += 2;
+         continue;
+      }
+
+      if (*p == '\0') {
+         MSG("premature end\n");
+         return -1;
+      }
+
+      if (p[0] == '"') {
+         p++;
+         break;
+      }
+
+      if (i >= n) {
+         MSG("too big\n");
+         return -1;
+      }
+      buf[i++] = *p;
+      p++;
+   }
+
+   if (i >= n) {
+      MSG("too big\n");
+      return -1;
+   }
+   buf[i] = '\0';
+
+   *next = p;
+
+   return 0;
+}
+
+int
+parse_keyword(char *p, char *keyword, char **next)
+{
+   while (*p == ' ')
+      p++;
+
+   int n = strlen(keyword);
+
+   if (strncmp(p, keyword, n) != 0) {
+      MSG("doesn't match keyword '%s' at p=%s\n", keyword, p);
+      return -1;
+   }
+
+   p += n;
+
+   /* Skip spaces after action */
+   while (*p == ' ')
+      p++;
+
+   *next = p;
+   return 0;
+}
+
+struct rule *
+parse_rule(char *line)
+{
+   char *p;
+   if (parse_keyword(line, "action", &p) != 0) {
+      MSG("cannot find keyword action\n");
+      return NULL;
+   }
+
+   char name[LINE_MAXLEN];
+   if (parse_string(p, name, LINE_MAXLEN, &p) != 0) {
+      MSG("failed parsing action name\n");
+      return NULL;
+   }
+
+   line = p;
+   if (parse_keyword(line, "shell", &p) != 0) {
+      MSG("cannot find keyword shell\n");
+      return NULL;
+   }
+
+   char cmd[LINE_MAXLEN];
+   if (parse_string(p, cmd, LINE_MAXLEN, &p) != 0) {
+      MSG("failed parsing shell command\n");
+      return NULL;
+   }
+
+   MSG("name = '%s', command = '%s'\n", name, cmd);
+
+   struct rule *rule = dNew(struct rule, 1);
+   rule->action = dStrdup(name);
+   rule->command = dStrdup(cmd);
+
+   return rule;
+}
+
+int
+a_Rules_init(void)
+{
+   memset(&rules, 0, sizeof(rules));
+
+   char *filename = dStrconcat(dGethomedir(), "/.dillo/rulesrc", NULL);
+   if (!filename) {
+      MSG("dStrconcat failed\n");
+      return -1;
+   }
+
+   FILE *f = fopen(filename, "r");
+   if (!f) {
+      /* No rules to parse */
+      return 0;
+   }
+
+   char line[LINE_MAXLEN];
+   while (!feof(f)) {
+      line[0] = '\0';
+      char *rc = fgets(line, LINE_MAXLEN, f);
+      if (!rc && ferror(f)) {
+         MSG("Error while reading rule from rulesrc: %s\n",
+             dStrerror(errno));
+         break; /* bail out */
+      }
+
+      /* Remove leading and trailing whitespaces */
+      dStrstrip(line);
+
+      if ((line[0] == '\0') || (line[0] == '#'))
+         continue;
+
+      MSG("RULE: %s\n", line);
+      struct rule *rule = parse_rule(line);
+      if (rule == NULL) {
+         MSG("Cannot parse rule: %s\n", line);
+         break;
+      }
+
+      if (rules.n < 256)
+         rules.rule[rules.n++] = rule;
+   }
+
+   fclose(f);
+   return 0;
+}
+
+struct rules *
+a_Rules_get(void)
+{
+   return &rules;
+}

--- a/src/rules.h
+++ b/src/rules.h
@@ -1,0 +1,36 @@
+/*
+ * File: rules.c
+ *
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef __RULES_H__
+#define __RULES_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/* Only one type of rule for now */
+struct rule {
+   char *action;
+   char *command;
+};
+
+struct rules {
+   struct rule *rule[256];
+   int n;
+};
+
+int a_Rules_init(void);
+struct rules *a_Rules_get(void);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* !__RULES_H__ */


### PR DESCRIPTION
Implements the logic to read rules from ~/.dillo/rulesrc which define custom actions to handle a URL. Here is an example:

  action "Open with MPV" shell "mpv $url"
  action "Open with MPV (only audio)" shell "mpv --no-video $url"
  action "Open with Firefox" shell "firefox $url"

The standard input and output is still redirected to the same file descriptor as Dillo.

The commands are spawned in a forked process using the system() call, which uses the shell to expand any variable. In particular, the $url variable is set to the current URL being opened.