### PR TITLE
Ignore meta refresh content without URL

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@ dillo-3.2.0 [Not released yet]
 +- Ignore empty page title for tab labels.
    Fix segfault when clicking the "Done" button in downloads dialog.
    Add zoom support using Ctrl +/-/0 and the "zoom_factor" option.
+   Fix wrong redirect by meta refresh without URL.
    Patches: Rodrigo Arias Mallo
 
 dillo-3.1.1 [Jun 8, 2024]

--- a/src/html.cc
+++ b/src/html.cc
@@ -3152,19 +3152,28 @@ static void Html_tag_open_meta(DilloHtml *html, const char *tag, int tagsize)
             sprintf(delay_str, ".");
          }
          /* Skip to anything after "URL=" or ";" if "URL=" is not found */
+         int has_url = 1;
          if ((p = dStriAsciiStr(content, "url=")))
             content = p + strlen("url=");
          else if ((p = strstr(content, ";")))
             content = p + strlen(";");
-         /* Handle the case of a quoted URL */
-         if (*content == '"' || *content == '\'') {
-            if ((p = strchr(content + 1, *content)))
-               mr_url = dStrndup(content + 1, p - content - 1);
-            else
-               mr_url = dStrdup(content + 1);
+         else
+            has_url = 0;
+
+         if (has_url) {
+            /* Handle the case of a quoted URL */
+            if (*content == '"' || *content == '\'') {
+               if ((p = strchr(content + 1, *content)))
+                  mr_url = dStrndup(content + 1, p - content - 1);
+               else
+                  mr_url = dStrdup(content + 1);
+            } else {
+               mr_url = dStrdup(content);
+            }
          } else {
-            mr_url = dStrdup(content);
+            mr_url = dStrdup("");
          }
+
          new_url = a_Html_url_new(html, mr_url, NULL, 0);
 
          if (a_Url_cmp(html->base_url, new_url) == 0) {

--- a/test/html/Makefile.am
+++ b/test/html/Makefile.am
@@ -23,6 +23,7 @@ TESTS = \
 	render/max-width-div-clamp.html \
 	render/max-width-html.html \
 	render/max-width-nested-div.html \
+	render/meta-refresh-0-no-url.html \
 	render/min-width-body.html \
 	render/min-width-div-extend.html \
 	render/min-width-div.html \

--- a/test/html/render/meta-refresh-0-no-url.html
+++ b/test/html/render/meta-refresh-0-no-url.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test meta refresh 0 without URL</title>
+    <meta http-equiv="Refresh" content="0">
+  </head>
+  <body>
+    <p>Should be ignored.</p>
+  </body>
+</html>

--- a/test/html/render/meta-refresh-0-no-url.ref.html
+++ b/test/html/render/meta-refresh-0-no-url.ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test meta refresh 0 without URL</title>
+  </head>
+  <body>
+    <p>Should be ignored.</p>
+  </body>
+</html>


### PR DESCRIPTION
The content="0" attribute was wrongly parsed as the URL "0". The change makes the parser ignore a redirect with a content value that doesn't have ";" or "url=" after the delay number.

Fixes: https://github.com/dillo-browser/dillo/issues/204