### PR TITLE
Check release fits in a floppy disk of 1.44 MB

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,20 @@ jobs:
       run: |
         export DILLOBIN=$(readlink -f install/bin/dillo)
         cd build && make check || (cat test/html/test-suite.log; false)
+        export DILLOBIN=
+    - name: Check release fits in a floppy disk of 1.44 MB
+      run: |
+        cd build
+        make dist-gzip
+        size=$(stat -c %s dillo-*.tar.gz)
+        floppy=1474560
+        echo "Floppy occupation: $(($size * 100 / $floppy)) %"
+        if [ $size -lt $floppy ]; then
+          echo 'OK: Fits in floopy disk'
+        else
+          echo "FAIL: Release size too big: $size / $floppy"
+          exit 1
+        fi
     - name: make distcheck (with HTML tests)
       run: |
         export DILLOBIN=


### PR DESCRIPTION
For now we check gzip as it is widely available and has a medium compression ratio.

Fixes: https://github.com/dillo-browser/dillo/issues/208