### PR TITLE
Fix ASan new-delete-type-mismatch error

### DIFF
--- a/lout/container.hh
+++ b/lout/container.hh
@@ -1,3 +1,23 @@
+/*
+ * Dillo Widget
+ *
+ * Copyright 2005-2007 Sebastian Geerken <sgeerken@dillo.org>
+ * Copyright 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef __LOUT_CONTAINER_HH_
 #define __LOUT_CONTAINER_HH_
 
@@ -231,6 +251,7 @@ protected:
    {
       object::Object *object;
       Node *next;
+      virtual ~Node() = default;
    };
 
    Node **table;


### PR DESCRIPTION
With the adreess sanitizer enabled there was an error:

>  AddressSanitizer: new-delete-type-mismatch

Caused by a size mismatch in the delete operator as the called destructor was the incorrect one.