### PR TITLE
Add anchor to HTML source lines and improve the design

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,7 @@ dillo-3.2.0 [Not released yet]
    Add zoom support using Ctrl +/-/0 and the "zoom_factor" option.
    Fix wrong redirect by meta refresh without URL.
    Display JSON as plain text.
+   Add line number anchors in HTML source view.
    Patches: Rodrigo Arias Mallo
 
 dillo-3.1.1 [Jun 8, 2024]

--- a/dpi/vsource.c
+++ b/dpi/vsource.c
@@ -120,12 +120,27 @@ void send_html_text(Dsh *sh, const char *url, int data_size)
                      "<html><head>\n"
                      "<title>Source for %s</title>\n"
                      "<style type=\"text/css\">\n"
-                     " body {white-space: pre-wrap; font-family: monospace}\n"
-                     " td.r1 {background-color:#B87333}\n"
-                     " td.r2 {background-color:#DD7F32}\n"
+                     "  body {\n"
+                     "    white-space: pre-wrap;\n"
+                     "    font-family: monospace;\n"
+                     "    margin: 0;\n"
+                     "    width: 100%;\n"
+                     "  }\n"
+                     "  table { border:0 }\n"
+                     "  td.num {\n"
+                     "    padding-top: 1px;\n"
+                     "    padding-bottom: 1px;\n"
+                     "    padding-left: 0.5em;\n"
+                     "    padding-right: 0.5em;\n"
+                     "    text-align: right;\n"
+                     "    border-right: 1px solid #999999;\n"
+                     "    background-color: #c6c6c6;\n"
+                     "  }"
+                     "  td.src { padding-left:0.25em; }\n"
+                     "  a { color: black; text-decoration:none; }\n"
                      "</style>\n"
                      "</head>\n"
-                     "<body id=\"dillo_vs\">\n<table cellpadding='0'>\n", url);
+                     "<body id=\"dillo_vs\">\n<table cellspacing='0' cellpadding='0'>\n", url);
 
    while (bytes_read < data_size &&
           (token = a_Dpip_dsh_read_token2(sh, 1, &token_size))) {
@@ -135,9 +150,8 @@ void send_html_text(Dsh *sh, const char *url, int data_size)
       while (*p) {
          if (line > old_line) {
             snprintf(line_str, 128,
-                     "<tr><td class='%s' id='L%d'><a href='#L%d'>%d%s</a><td>",
-                     (line & 1) ? "r1" : "r2", line, line, line,
-                     (line == 1 || (line % 10) == 0) ? "&nbsp;" : "");
+                     "<tr><td class='num' id='L%d'><a href='#L%d'>%d</a><td class='src'>",
+                     line, line, line);
             a_Dpip_dsh_write_str(sh, 0, line_str);
             old_line = line;
          }

--- a/dpi/vsource.c
+++ b/dpi/vsource.c
@@ -4,6 +4,7 @@
  * This server is an example. Play with it and modify to your taste.
  *
  * Copyright 2010-2015 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -134,8 +135,8 @@ void send_html_text(Dsh *sh, const char *url, int data_size)
       while (*p) {
          if (line > old_line) {
             snprintf(line_str, 128,
-                     "<tr><td class='%s'>%d%s<td>",
-                     (line & 1) ? "r1" : "r2", line,
+                     "<tr><td class='%s' id='L%d'><a href='#L%d'>%d%s</a><td>",
+                     (line & 1) ? "r1" : "r2", line, line, line,
                      (line == 1 || (line % 10) == 0) ? "&nbsp;" : "");
             a_Dpip_dsh_write_str(sh, 0, line_str);
             old_line = line;


### PR DESCRIPTION
Adds a line anchor so we can make hyperlinks to an specific line.

Additionally improves a bit the design of the line number colors:

Here is the old style:
![line-numbers-old](https://github.com/dillo-browser/dillo/assets/3866127/14c173c1-cf5e-4eaa-85c9-342f34713240)

And new:
![line-numbers-new](https://github.com/dillo-browser/dillo/assets/3866127/0445f098-200b-48d6-8141-8cc014dff06b)