### PR TITLE
Render JSON content as plain text

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ dillo-3.2.0 [Not released yet]
    Fix segfault when clicking the "Done" button in downloads dialog.
    Add zoom support using Ctrl +/-/0 and the "zoom_factor" option.
    Fix wrong redirect by meta refresh without URL.
+   Display JSON as plain text.
    Patches: Rodrigo Arias Mallo
 
 dillo-3.1.1 [Jun 8, 2024]

--- a/src/IO/mime.c
+++ b/src/IO/mime.c
@@ -2,6 +2,7 @@
  * File: mime.c
  *
  * Copyright (C) 2000-2007 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -109,6 +110,7 @@ void a_Mime_init()
 #endif
    Mime_add_minor_type("text/html", a_Html_text);
    Mime_add_minor_type("application/xhtml+xml", a_Html_text);
+   Mime_add_minor_type("application/json", a_Plain_text);
 
    /* Add a major type to handle all the text stuff */
    Mime_add_major_type("text", a_Plain_text);


### PR DESCRIPTION
Some website endpoints return information in JSON, which is helpful to be read as plain text in some situations.

An example is the following endpoint https://tls.browserleaks.com/tls, which provides TLS fingerprinting information in JSON, which will change when reloading the page (only when Dillo is linked with LibreSSL).

The original page https://tls.browserleaks.com/ uses JS and cannot be used in Dillo.

See: https://lists.mailman3.com/hyperkitty/list/dillo-dev@mailman3.com/message/6C5K4F6NBRUDSPNPWTXLQXCK3U3SI7DM/