### PR TITLE
Make Dillo strictly compliant with C90, C++11 and POSIX-2001

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
     - name: autogen
       run: ./autogen.sh
     - name: configure
-      run: ./configure --disable-mbedtls CFLAGS="-std=gnu99" CXXFLAGS="-std=c++98"
+      run: ./configure --disable-mbedtls CFLAGS="-Werror" CXXFLAGS="-Werror"
     - name: make
       run: make
     - name: make check

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,11 +11,13 @@ dillo-3.2.0 [Not released yet]
 +- Add new_tab_page option to open a custom new tab page.
    Patches: Alex, Rodrigo Arias Mallo
 +- Ignore empty page title for tab labels.
-   Fix segfault when clicking the "Done" button in downloads dialog.
-   Add zoom support using Ctrl +/-/0 and the "zoom_factor" option.
-   Fix wrong redirect by meta refresh without URL.
-   Display JSON as plain text.
-   Add line number anchors in HTML source view.
+ - Fix segfault when clicking the "Done" button in downloads dialog.
+ - Add zoom support using Ctrl +/-/0 and the "zoom_factor" option.
+ - Fix wrong redirect by meta refresh without URL.
+ - Display JSON as plain text.
+ - Add line number anchors in HTML source view.
+ - Make Dillo strictly C99, C++11 and POSIX-2001 compliant, without depending on
+   GNU extensions.
    Patches: Rodrigo Arias Mallo
 +- Add primitive support for SVG using the nanosvg.h library.
    Patches: dogma, Rodrigo Arias Mallo

--- a/configure.ac
+++ b/configure.ac
@@ -665,7 +665,7 @@ dnl -----------
 dnl
 
 if eval "test x$GCC = xyes"; then
-  CXXFLAGS="$CXXFLAGS -Wall -W -Wno-unused-parameter -fno-rtti -fno-exceptions"
+  CXXFLAGS="$CXXFLAGS -Wall -W -Wno-unused-parameter -fno-rtti -fno-exceptions -pedantic -std=c++11"
 fi
 
 AC_SUBST(BASE_CUR_WORKING_DIR)

--- a/configure.ac
+++ b/configure.ac
@@ -655,7 +655,9 @@ if eval "test x$GCC = xyes"; then
   if test "`echo $CFLAGS | grep '\-Wno-unused-parameter' 2> /dev/null`" = ""; then
     CFLAGS="$CFLAGS -Wno-unused-parameter"
   fi
+  CFLAGS="$CFLAGS -pedantic -std=c99 -D_POSIX_C_SOURCE=200112L"
 fi
+
 dnl -----------
 dnl CXX options
 dnl -----------

--- a/configure.ac
+++ b/configure.ac
@@ -706,6 +706,8 @@ AC_OUTPUT
 _AS_ECHO([])
 _AS_ECHO([Configuration summary:])
 _AS_ECHO([])
+_AS_ECHO([  CC      : ${CC}])
+_AS_ECHO([  CFLAGS  : ${CFLAGS}])
 _AS_ECHO([  CXX     : ${CXX}])
 _AS_ECHO([  CXXFLAGS: ${CXXFLAGS}])
 _AS_ECHO([])

--- a/configure.ac
+++ b/configure.ac
@@ -655,9 +655,6 @@ if eval "test x$GCC = xyes"; then
   if test "`echo $CFLAGS | grep '\-Wno-unused-parameter' 2> /dev/null`" = ""; then
     CFLAGS="$CFLAGS -Wno-unused-parameter"
   fi
-  if test "`echo $CFLAGS | grep '\-Waggregate-return' 2> /dev/null`" = ""; then
-    CFLAGS="$CFLAGS -Waggregate-return"
-  fi
 fi
 dnl -----------
 dnl CXX options

--- a/configure.ac
+++ b/configure.ac
@@ -664,7 +664,7 @@ dnl -----------
 dnl
 
 if eval "test x$GCC = xyes"; then
-  CXXFLAGS="$CXXFLAGS -Wall -W -Wno-unused-parameter -fno-rtti -fno-exceptions -pedantic -std=c++11"
+  CXXFLAGS="$CXXFLAGS -Wall -W -Wno-unused-parameter -fno-rtti -fno-exceptions -pedantic -std=c++11 -D_POSIX_C_SOURCE=200112L"
 fi
 
 AC_SUBST(BASE_CUR_WORKING_DIR)

--- a/dlib/dlib.c
+++ b/dlib/dlib.c
@@ -883,7 +883,7 @@ void dLib_show_messages(bool_t show)
 /**
  * Return the current working directory in a new string
  */
-char *dGetcwd ()
+char *dGetcwd (void)
 {
   size_t size = 128;
 
@@ -901,7 +901,7 @@ char *dGetcwd ()
 /**
  * Return the home directory in a static string (don't free)
  */
-char *dGethomedir ()
+char *dGethomedir (void)
 {
    static char *homedir = NULL;
 

--- a/dlib/dlib.c
+++ b/dlib/dlib.c
@@ -2,6 +2,7 @@
  * File: dlib.c
  *
  * Copyright (C) 2006-2007 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,6 +25,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <ctype.h>
+#include <time.h>
 
 #include "dlib.h"
 
@@ -954,4 +956,25 @@ int dClose(int fd)
       st = close(fd);
    while (st == -1 && errno == EINTR);
    return st;
+}
+
+/**
+ * Portable usleep() function.
+ *
+ * The usleep() function is deprecated in POSIX.1-2001 and removed in
+ * POSIX.1-2008, see usleep(3).
+ */
+int dUsleep(unsigned long usec)
+{
+	struct timespec ts;
+	int res;
+
+	ts.tv_sec = usec / 1000000UL;
+	ts.tv_nsec = (usec % 1000000UL) * 1000UL;
+
+	do {
+		res = nanosleep(&ts, &ts);
+	} while (res && errno == EINTR);
+
+	return res;
 }

--- a/dlib/dlib.h
+++ b/dlib/dlib.h
@@ -177,6 +177,7 @@ char *dGetcwd(void);
 char *dGethomedir(void);
 char *dGetline(FILE *stream);
 int dClose(int fd);
+int dUsleep(unsigned long us);
 
 #ifdef __cplusplus
 }

--- a/dlib/dlib.h
+++ b/dlib/dlib.h
@@ -173,8 +173,8 @@ void dLib_show_messages(bool_t show);
 /*
  *- Misc utility functions ----------------------------------------------------
  */
-char *dGetcwd();
-char *dGethomedir();
+char *dGetcwd(void);
+char *dGethomedir(void);
 char *dGetline(FILE *stream);
 int dClose(int fd);
 

--- a/dpi/cookies.c
+++ b/dpi/cookies.c
@@ -3,7 +3,7 @@
  * Cookies server.
  *
  * Copyright 2001 Lars Clausen   <lrclause@cs.uiuc.edu>
- *                Jörgen Viksell <jorgen.viksell@telia.com>
+ *                JÃ¶rgen Viksell <jorgen.viksell@telia.com>
  * Copyright 2002-2007 Jorge Arellano Cid <jcid@dillo.org>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -332,7 +332,7 @@ static void Cookies_load_cookies(FILE *stream)
  * Initialize the cookies module
  * (The 'disabled' variable is writeable only within Cookies_init)
  */
-static void Cookies_init()
+static void Cookies_init(void)
 {
    char *filename;
 #ifndef HAVE_LOCKF
@@ -387,7 +387,7 @@ static void Cookies_init()
 /*
  * Flush cookies to disk and free all the memory allocated.
  */
-static void Cookies_save_and_free()
+static void Cookies_save_and_free(void)
 {
    int i, fd, saved = 0;
    DomainNode *node;

--- a/dpi/datauri.c
+++ b/dpi/datauri.c
@@ -20,6 +20,7 @@
 
 #include "../dpip/dpip.h"
 #include "dpiutil.h"
+#include "../src/misc.h"
 
 /*
  * Debugging macros
@@ -44,7 +45,7 @@ static void b64strip_illegal_chars(unsigned char* str)
    MSG("len=%d{%s}\n", strlen((char*)str), str);
 
    for (p = s; (*p = *s); ++s) {
-      if (isascii(*p) && (isalnum(*p) || strchr("+/=", *p)))
+      if (d_isascii(*p) && (isalnum(*p) || strchr("+/=", *p)))
          ++p;
    }
 

--- a/dpi/downloads.cc
+++ b/dpi/downloads.cc
@@ -679,11 +679,11 @@ static void secs2timestr(int et, char *str)
    eh = et / 3600; em = (et % 3600) / 60; es = et % 60;
    if (eh == 0) {
       if (em == 0)
-         snprintf(str, 8, "%ds", es);
+         snprintf(str, 16, "%ds", es);
       else
-         snprintf(str, 8, "%dm%ds", em, es);
+         snprintf(str, 16, "%dm%ds", em, es);
    } else {
-      snprintf(str, 8, "%dh%dm", eh, em);
+      snprintf(str, 16, "%dh%dm", eh, em);
    }
 }
 

--- a/dpi/file.c
+++ b/dpi/file.c
@@ -1000,7 +1000,7 @@ static void File_serve_client(void *data, int f_write)
 /*
  * Serve the client queue.
  */
-static void File_serve_clients()
+static void File_serve_clients(void)
 {
    int i, f_read, f_write;
    ClientInfo *client;

--- a/dpid/dpid.c
+++ b/dpid/dpid.c
@@ -47,7 +47,7 @@ char *SharedKey = NULL;
  * This avoids that dillo instances connect to a stale port after dpid
  * has exited (e.g. after a reboot).
  */
-void cleanup()
+void cleanup(void)
 {
    char *fname;
    fname = dStrconcat(dGethomedir(), "/", dotDILLO_DPID_COMM_KEYS, NULL);
@@ -112,7 +112,7 @@ static void terminator(int sig)
 
 /*! Establish handler for termination signals
  * and register cleanup with atexit */
-void est_dpi_terminator()
+void est_dpi_terminator(void)
 {
    struct sigaction act;
    sigset_t block;
@@ -526,7 +526,7 @@ int fill_services_list(struct dp *attlist, int numdpis, Dlist **services_list)
  * Return a socket file descriptor
  * (useful to set socket options in a uniform way)
  */
-static int make_socket_fd()
+static int make_socket_fd(void)
 {
    int ret, one = 1;
 
@@ -618,7 +618,7 @@ int save_comm_keys(int srs_port)
  * \li Number of sockets (1 == success)
  * \li -1 on failure
  */
-int init_ids_srs_socket()
+int init_ids_srs_socket(void)
 {
    int srs_port, ret = -1;
 
@@ -806,7 +806,7 @@ void ignore_dpi_sockets(struct dp *dpi_attr_list, int numdpis)
  * \Return
  * Number of available dpis
  */
-int register_all_cmd()
+int register_all_cmd(void)
 {
    stop_active_dpis(dpi_attr_list, numdpis);
    free_plugin_list(&dpi_attr_list, numdpis);

--- a/dpid/dpid.c
+++ b/dpid/dpid.c
@@ -25,7 +25,9 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <arpa/inet.h>
 
 #include <unistd.h>
 #include "dpid_common.h"
@@ -564,7 +566,7 @@ int bind_socket_fd(int base_port, int *p_port)
 
    memset(&sin, 0, sizeof(sin));
    sin.sin_family = AF_INET;
-   sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+   sin.sin_addr.s_addr = inet_addr("127.0.0.1");
 
    /* Try to bind a port on localhost */
    for (port = base_port; port <= last_port; ++port) {
@@ -754,7 +756,7 @@ void stop_active_dpis(struct dp *dpi_attr_list, int numdpis)
 
    memset(&sin, 0, sizeof(sin));
    sin.sin_family = AF_INET;
-   sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+   sin.sin_addr.s_addr = inet_addr("127.0.0.1");
 
    for (i = 0; i < numdpis; i++) {
       /* Skip inactive dpis and filters */

--- a/dpid/dpid.h
+++ b/dpid/dpid.h
@@ -68,7 +68,7 @@ extern volatile sig_atomic_t caught_sigchld;
 
 void rm_dpi_sockets(struct dp *dpi_attr_list, int numdpis);
 
-void cleanup();
+void cleanup(void);
 
 void free_dpi_attr(struct dp *dpi_attr);
 
@@ -86,7 +86,7 @@ int register_all(struct dp **attlist);
 
 int fill_services_list(struct dp *attlist, int numdpis, Dlist **services_list);
 
-int init_ids_srs_socket();
+int init_ids_srs_socket(void);
 
 int init_dpi_socket(struct dp *dpi_attr);
 
@@ -104,7 +104,7 @@ void stop_active_dpis(struct dp *dpi_attr_list, int numdpis);
 
 void ignore_dpi_sockets(struct dp *dpi_attr_list, int numdpis);
 
-int register_all_cmd();
+int register_all_cmd(void);
 
 char *get_message(int sock, char *dpi_tag);
 

--- a/dpid/dpid_common.h
+++ b/dpid/dpid_common.h
@@ -10,6 +10,8 @@
  */
 
 #include <dirent.h>
+#include <stddef.h> /* size_t */
+#include <sys/types.h> /* ssize_t */
 
 #include "../dlib/dlib.h"
 

--- a/dpid/dpidc.c
+++ b/dpid/dpidc.c
@@ -16,6 +16,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <arpa/inet.h>
 #include <netdb.h>
 #include <errno.h>
 
@@ -91,7 +92,7 @@ int main(int argc, char *argv[])
         error("ERROR opening socket");
     memset(&serv_addr, 0, sizeof(serv_addr));
     serv_addr.sin_family = AF_INET;
-    serv_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    serv_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
 
     serv_addr.sin_port = htons(portno);
     if (connect(sockfd, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0)

--- a/dpid/main.c
+++ b/dpid/main.c
@@ -48,7 +48,6 @@ struct dp *dpi_attr_list;
 Dlist *services_list;
 int numsocks;
 int srs_fd;
-;
 
 // end of fix
 

--- a/dpid/misc_new.c
+++ b/dpid/misc_new.c
@@ -59,7 +59,7 @@ char *a_Misc_readtag(int sock)
 {
    char *tag, c;
    size_t i;
-   size_t taglen = 0, tagmem = 10;
+   size_t tagmem = 10;
    ssize_t rdln = 1;
 
    tag = NULL;
@@ -71,7 +71,6 @@ char *a_Misc_readtag(int sock)
          tag = (char *) dRealloc(tag, tagmem + 1);
       }
       tag[i] = c;
-      taglen += rdln;
       if (c == '>') {
          tag[i + 1] = '\0';
          break;

--- a/dw/findtext.cc
+++ b/dw/findtext.cc
@@ -20,6 +20,7 @@
 
 
 #include "core.hh"
+#include "dlib/dlib.h"
 #include "../lout/debug.hh"
 #include "../lout/msg.h"
 
@@ -87,7 +88,7 @@ FindtextState::Result FindtextState::search (const char *key, bool caseSens,
       newKey = true;
       if (this->key)
          free(this->key);
-      this->key = strdup (key);
+      this->key = dStrdup (key);
       this->caseSens = caseSens;
 
       if (nexttab)

--- a/dw/fltkcomplexbutton.cc
+++ b/dw/fltkcomplexbutton.cc
@@ -63,6 +63,7 @@ int ComplexButton::handle(int event) {
     return 1;
   case FL_PUSH:
     if (Fl::visible_focus() && handle(FL_FOCUS)) Fl::focus(this);
+    /* fallthrough */
   case FL_DRAG:
     if (Fl::event_inside(this)) {
       newval = !oldval;
@@ -107,6 +108,7 @@ int ComplexButton::handle(int event) {
       value(0);
       return 1;
     }
+    /* fallthrough */
   default:
     return 0;
   }

--- a/dw/fltkimgbuf.cc
+++ b/dw/fltkimgbuf.cc
@@ -324,7 +324,8 @@ inline void FltkImgbuf::scaleBuffer (const core::byte *src, int srcWidth,
       gammaMap2 = findGammaCorrectionTable (1 / gamma);
    }
 
-   for(int x = 0; x < destWidth; x++)
+   int *v = new int[bpp];
+   for(int x = 0; x < destWidth; x++) {
       for(int y = 0; y < destHeight; y++) {
          int xo1 = x * srcWidth / destWidth;
          int xo2 = lout::misc::max ((x + 1) * srcWidth / destWidth, xo1 + 1);
@@ -332,7 +333,6 @@ inline void FltkImgbuf::scaleBuffer (const core::byte *src, int srcWidth,
          int yo2 = lout::misc::max ((y + 1) * srcHeight / destHeight, yo1 + 1);
          int n = (xo2 - xo1) * (yo2 - yo1);
 
-         int v[bpp];
          for(int i = 0; i < bpp; i++)
             v[i] = 0;
 
@@ -349,6 +349,8 @@ inline void FltkImgbuf::scaleBuffer (const core::byte *src, int srcWidth,
             pd[i] =
                scaleMode == BEAUTIFUL_GAMMA ? gammaMap1[v[i] / n] : v[i] / n;
       }
+   }
+   delete[] v;
 }
 
 void FltkImgbuf::copyRow (int row, const core::byte *data)

--- a/dw/fltkplatform.cc
+++ b/dw/fltkplatform.cc
@@ -497,7 +497,7 @@ void FltkPlatform::detachView (core::View *view)
 {
    if (this->view != view)
       MSG_ERR("FltkPlatform::detachView: this->view: %p view: %p\n",
-              this->view, view);
+              (void *) this->view, (void *) view);
 
    for (container::typed::Iterator <ui::FltkResource> it =
            resources->iterator (); it.hasNext (); ) {

--- a/dw/fltkplatform.cc
+++ b/dw/fltkplatform.cc
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 
+#include "dlib/dlib.h"
 #include "../lout/msg.h"
 #include "../lout/debug.hh"
 #include "fltkcore.hh"
@@ -145,7 +146,7 @@ void FltkFont::initSystemFonts ()
    int k = Fl::set_fonts ("-*-iso10646-1");
    for (int i = 0; i < k; i++) {
       int t;
-      char *name = strdup (Fl::get_font_name ((Fl_Font) i, &t));
+      char *name = dStrdup (Fl::get_font_name ((Fl_Font) i, &t));
 
       // normalize font family names (strip off "bold", "italic")
       if (t & FL_ITALIC)

--- a/dw/fltkui.cc
+++ b/dw/fltkui.cc
@@ -460,7 +460,7 @@ void FltkResource::detachView (FltkView *view)
 {
    if (this->view != view)
       MSG_ERR("FltkResource::detachView: this->view: %p view: %p\n",
-              this->view, view);
+              (void *) this->view, (void *) view);
    this->view = NULL;
 }
 

--- a/dw/fltkui.cc
+++ b/dw/fltkui.cc
@@ -22,6 +22,7 @@
 #include "fltkcore.hh"
 #include "fltkflatview.hh"
 #include "fltkcomplexbutton.hh"
+#include "dlib/dlib.h"
 #include "../lout/msg.h"
 #include "../lout/misc.hh"
 
@@ -112,7 +113,7 @@ void CustInput2::set_placeholder(const char *str)
 {
    if (placeholder)
       free(placeholder);
-   placeholder = strdup(str);
+   placeholder = dStrdup(str);
 
    if ((Fl::focus() != this) && !*value()) {
       show_placeholder();
@@ -276,7 +277,7 @@ void CustTextEditor::set_placeholder(const char *str)
 {
    if (placeholder)
       free(placeholder);
-   placeholder = strdup(str);
+   placeholder = dStrdup(str);
 
    if ((Fl::focus() != this) && buffer()->length() == 0) {
       show_placeholder();
@@ -315,7 +316,7 @@ char* CustTextEditor::value()
     */
    if (text_copy)
       free(text_copy);
-   text_copy = showing_placeholder ? strdup("") : buffer()->text();
+   text_copy = showing_placeholder ? dStrdup("") : buffer()->text();
    return text_copy;
 }
 
@@ -625,7 +626,7 @@ FltkLabelButtonResource::FltkLabelButtonResource (FltkPlatform *platform,
                                                   const char *label):
    FltkSpecificResource <dw::core::ui::LabelButtonResource> (platform)
 {
-   this->label = strdup (label);
+   this->label = dStrdup (label);
    init (platform);
 }
 
@@ -717,7 +718,7 @@ const char *FltkLabelButtonResource::getLabel ()
 void FltkLabelButtonResource::setLabel (const char *label)
 {
    free((char *)this->label);
-   this->label = strdup (label);
+   this->label = dStrdup (label);
 
    widget->label (this->label);
    queueResize (true);
@@ -866,9 +867,9 @@ FltkEntryResource::FltkEntryResource (FltkPlatform *platform, int size,
 {
    this->size = size;
    this->password = password;
-   this->label = label ? strdup(label) : NULL;
+   this->label = label ? dStrdup(label) : NULL;
    this->label_w = 0;
-   this->placeholder = placeholder ? strdup(placeholder) : NULL;
+   this->placeholder = placeholder ? dStrdup(placeholder) : NULL;
 
    initText = NULL;
    editable = false;
@@ -994,7 +995,7 @@ void FltkEntryResource::setText (const char *text)
 {
    if (initText)
       free((char *)initText);
-   initText = strdup (text);
+   initText = dStrdup (text);
 
    ((CustInput2*)widget)->value (initText);
 }
@@ -1052,7 +1053,7 @@ FltkMultiLineTextResource::FltkMultiLineTextResource (FltkPlatform *platform,
       MSG_WARN("numRows = %d is set to 1.\n", numRows);
       numRows = 1;
    }
-   this->placeholder = placeholder ? strdup(placeholder) : NULL;
+   this->placeholder = placeholder ? dStrdup(placeholder) : NULL;
 
    init (platform);
 }
@@ -1492,7 +1493,7 @@ void FltkOptionMenuResource::addItem (const char *str,
 {
    Fl_Menu_Item *item = newItem();
 
-   item->text = strdup(str);
+   item->text = dStrdup(str);
 
    if (enabled == false)
       item->flags = FL_MENU_INACTIVE;
@@ -1513,7 +1514,7 @@ void FltkOptionMenuResource::pushGroup (const char *name, bool enabled)
 {
    Fl_Menu_Item *item = newItem();
 
-   item->text = strdup(name);
+   item->text = dStrdup(name);
 
    if (enabled == false)
       item->flags = FL_MENU_INACTIVE;

--- a/dw/fltkviewport.cc
+++ b/dw/fltkviewport.cc
@@ -121,13 +121,15 @@ void FltkViewport::adjustScrollbarsAndGadgetsAllocation ()
    vscrollbar->resize(x () + w () - SCROLLBAR_THICKNESS, y (),
                       SCROLLBAR_THICKNESS, h () - vdiff);
 
-   int X = x () + w () - SCROLLBAR_THICKNESS;
-   int Y = y () + h () - SCROLLBAR_THICKNESS;
+   //int X = x () + w () - SCROLLBAR_THICKNESS;
+   //int Y = y () + h () - SCROLLBAR_THICKNESS;
    for (Iterator <TypedPointer < Fl_Widget> > it = gadgets->iterator ();
         it.hasNext (); ) {
       Fl_Widget *widget = it.getNext()->getTypedValue ();
       widget->resize(x (), y (), SCROLLBAR_THICKNESS, SCROLLBAR_THICKNESS);
 
+      /* FIXME: This has no effect */
+#if 0
       switch (gadgetOrientation [visibility]) {
       case GADGET_VERTICAL:
          Y -= SCROLLBAR_THICKNESS;
@@ -137,6 +139,7 @@ void FltkViewport::adjustScrollbarsAndGadgetsAllocation ()
          X -= SCROLLBAR_THICKNESS;
          break;
       }
+#endif
    }
 }
 

--- a/dw/hyphenator.cc
+++ b/dw/hyphenator.cc
@@ -21,6 +21,7 @@
 
 #include "hyphenator.hh"
 
+#include "dlib/dlib.h"
 #include "../lout/misc.hh"
 #include "../lout/unicode.hh"
 #include <limits.h>
@@ -395,7 +396,7 @@ TrieBuilder::~TrieBuilder ()
 void TrieBuilder::insert (const char *key, const char *value)
 {
    dataList->increase ();
-   dataList->getLastRef ()->key = (unsigned char *) strdup(key);
+   dataList->getLastRef ()->key = (unsigned char *) dStrdup(key);
    dataList->getLastRef ()->value = dataZone->strdup (value);
 }
 

--- a/dw/image.cc
+++ b/dw/image.cc
@@ -20,6 +20,7 @@
 
 
 #include "image.hh"
+#include "dlib/dlib.h"
 #include "../lout/msg.h"
 #include "../lout/misc.hh"
 #include "../lout/debug.hh"
@@ -146,7 +147,7 @@ Image::Image(const char *altText)
 {
    DBG_OBJ_CREATE ("dw::Image");
    registerName ("dw::Image", &CLASS_ID);
-   this->altText = altText ? strdup (altText) : NULL;
+   this->altText = altText ? dStrdup (altText) : NULL;
    altTextWidth = -1; // not yet calculated
    buffer = NULL;
    bufWidth = bufHeight = -1;

--- a/dw/layout.cc
+++ b/dw/layout.cc
@@ -22,6 +22,7 @@
 
 #include "core.hh"
 
+#include "dlib/dlib.h"
 #include "../lout/msg.h"
 #include "../lout/debug.hh"
 #include "../lout/misc.hh"
@@ -735,7 +736,7 @@ void Layout::setAnchor (const char *anchor)
 
    if (requestedAnchor)
       free (requestedAnchor);
-   requestedAnchor = anchor ? strdup (anchor) : NULL;
+   requestedAnchor = anchor ? dStrdup (anchor) : NULL;
    updateAnchor ();
 }
 
@@ -754,7 +755,7 @@ char *Layout::addAnchor (Widget *widget, const char* name, int y)
       return NULL;
    else {
       Anchor *anchor = new Anchor ();
-      anchor->name = strdup (name);
+      anchor->name = dStrdup (name);
       anchor->widget = widget;
       anchor->y = y;
 

--- a/dw/layout.cc
+++ b/dw/layout.cc
@@ -504,8 +504,10 @@ void Layout::attachView (View *view)
 
 void Layout::detachView (View *view)
 {
-   if (this->view != view)
-      MSG_ERR("detachView: this->view: %p view %p\n", this->view, view);
+   if (this->view != view) {
+      MSG_ERR("detachView: this->view: %p view %p\n",
+            (void *) this->view, (void *) view);
+   }
 
    view->setLayout (NULL);
    platform->detachView (view);
@@ -865,7 +867,7 @@ void Layout::resizeIdle ()
 
    enterResizeIdle ();
 
-   static int calls = 0;
+   //static int calls = 0;
 
    // There are two commits, 2863:b749629fbfc9 and 4645:ab70f9ce4353, the second
    // reverting the former. Interrestingly, the second fixes a bug. However, it

--- a/dw/ooffloatsmgr.cc
+++ b/dw/ooffloatsmgr.cc
@@ -548,7 +548,7 @@ int OOFFloatsMgr::addWidgetOOF (Widget *widget, OOFAwareWidget *generatingBlock,
    DBG_OBJ_ENTER ("construct.oofm", 0, "addWidgetOOF", "%p, %p, %d",
                   widget, generatingBlock, externalIndex);
 
-   int subRef;
+   int subRef = 0;
 
    TBInfo *tbInfo = getOOFAwareWidget (generatingBlock);
    Float *vloat = new Float (this, widget, generatingBlock, externalIndex);

--- a/dw/style.cc
+++ b/dw/style.cc
@@ -773,6 +773,7 @@ static void drawBorderTop(View *view, Style *style,
       break;
    case BORDER_DOTTED:
       dotted = true;
+      /* fallthrough */
    case BORDER_DASHED:
       w = style->borderWidth.top;
       view->drawTypedLine(style->borderColor.top, shading,
@@ -782,6 +783,7 @@ static void drawBorderTop(View *view, Style *style,
    case BORDER_SOLID:
    case BORDER_INSET:
       inset = true;
+      /* fallthrough */
    case BORDER_OUTSET:
       if (style->borderStyle.top != BORDER_SOLID)
          shading = (inset) ? Color::SHADING_DARK : Color::SHADING_LIGHT;
@@ -801,6 +803,7 @@ static void drawBorderTop(View *view, Style *style,
       break;
    case BORDER_RIDGE:
       ridge = true;
+      /* fallthrough */
    case BORDER_GROOVE:
       d = style->borderWidth.top & 1;
       points[0].x = x1;
@@ -870,6 +873,7 @@ static void drawBorderBottom(View *view, Style *style,
       break;
    case BORDER_DOTTED:
       dotted = true;
+      /* fallthrough */
    case BORDER_DASHED:
       w = style->borderWidth.bottom;
       view->drawTypedLine(style->borderColor.bottom, shading,
@@ -879,6 +883,7 @@ static void drawBorderBottom(View *view, Style *style,
    case BORDER_SOLID:
    case BORDER_INSET:
       inset = true;
+      /* fallthrough */
    case BORDER_OUTSET:
       if (style->borderStyle.bottom != BORDER_SOLID)
          shading = (inset) ? Color::SHADING_LIGHT : Color::SHADING_DARK;
@@ -898,6 +903,7 @@ static void drawBorderBottom(View *view, Style *style,
       break;
    case BORDER_RIDGE:
       ridge = true;
+      /* fallthrough */
    case BORDER_GROOVE:
       w = style->borderWidth.bottom;
       d = w & 1;
@@ -969,6 +975,7 @@ static void drawBorderLeft(View *view, Style *style,
       break;
    case BORDER_DOTTED:
       dotted = true;
+      /* fallthrough */
    case BORDER_DASHED:
       w = style->borderWidth.left;
       view->drawTypedLine(style->borderColor.left, shading,
@@ -978,6 +985,7 @@ static void drawBorderLeft(View *view, Style *style,
    case BORDER_SOLID:
    case BORDER_INSET:
       inset = true;
+      /* fallthrough */
    case BORDER_OUTSET:
       if (style->borderStyle.left != BORDER_SOLID)
          shading = (inset) ? Color::SHADING_DARK : Color::SHADING_LIGHT;
@@ -996,6 +1004,7 @@ static void drawBorderLeft(View *view, Style *style,
       break;
    case BORDER_RIDGE:
       ridge = true;
+      /* fallthrough */
    case BORDER_GROOVE:
       w = style->borderWidth.left;
       d = w & 1;
@@ -1066,6 +1075,7 @@ static void drawBorderRight(View *view, Style *style,
       break;
    case BORDER_DOTTED:
       dotted = true;
+      /* fallthrough */
    case BORDER_DASHED:
       w = style->borderWidth.right;
       view->drawTypedLine(style->borderColor.right, shading,
@@ -1075,6 +1085,7 @@ static void drawBorderRight(View *view, Style *style,
    case BORDER_SOLID:
    case BORDER_INSET:
       inset = true;
+      /* fallthrough */
    case BORDER_OUTSET:
       if (style->borderStyle.right != BORDER_SOLID)
          shading = (inset) ? Color::SHADING_LIGHT : Color::SHADING_DARK;
@@ -1093,6 +1104,7 @@ static void drawBorderRight(View *view, Style *style,
       break;
    case BORDER_RIDGE:
       ridge = true;
+      /* fallthrough */
    case BORDER_GROOVE:
       w = style->borderWidth.right;
       d = w & 1;
@@ -1419,6 +1431,7 @@ void numtostr (int num, char *buf, int buflen, ListStyleType listStyleType)
    case LIST_STYLE_TYPE_LOWER_ALPHA:
    case LIST_STYLE_TYPE_LOWER_LATIN:
       start_ch = 'a';
+      /* fallthrough */
    case LIST_STYLE_TYPE_UPPER_ALPHA:
    case LIST_STYLE_TYPE_UPPER_LATIN:
       i0 = num - 1;
@@ -1433,6 +1446,7 @@ void numtostr (int num, char *buf, int buflen, ListStyleType listStyleType)
       break;
    case LIST_STYLE_TYPE_LOWER_ROMAN:
       low = true;
+      /* fallthrough */
    case LIST_STYLE_TYPE_UPPER_ROMAN:
       i0 = num;
       i1 = i0/10; i2 = i1/10; i3 = i2/10;

--- a/dw/style.cc
+++ b/dw/style.cc
@@ -23,6 +23,7 @@
 #include <ctype.h>
 #include <math.h>
 
+#include "dlib/dlib.h"
 #include "core.hh"
 #include "../lout/msg.h"
 
@@ -426,7 +427,7 @@ Font::~Font ()
 
 void Font::copyAttrs (FontAttrs *attrs)
 {
-   name = strdup (attrs->name);
+   name = dStrdup (attrs->name);
    size = attrs->size;
    weight = attrs->weight;
    style = attrs->style;

--- a/dw/table.cc
+++ b/dw/table.cc
@@ -1196,10 +1196,13 @@ void Table::actuallyCalcCellSizes (bool calcHeights)
          for (int col = 0; col < numCols; col++) {
             int n = row * numCols + col;
             if (childDefined (n)) {
+               /* FIXME: Variable width is not used */
+#if 0
                int width = (children->get(n)->cell.colspanEff - 1)
                   * getStyle()->hBorderSpacing;
                for (int i = 0; i < children->get(n)->cell.colspanEff; i++)
                   width += colWidths->get (col + i);
+#endif
 
                core::Requisition childRequisition;
                //children->get(n)->cell.widget->setWidth (width);

--- a/dw/table.cc
+++ b/dw/table.cc
@@ -714,6 +714,7 @@ void Table::setColExtreme (int col, ExtrMod mod, void *data, int value)
    switch (mod) {
    case DATA:
       ((misc::SimpleVector<int>*)data)->set (col, value);
+      /* fallthrough */
 
    default:
       setExtreme (colExtremes->getRef(col), mod, value);

--- a/dw/table.hh
+++ b/dw/table.hh
@@ -325,6 +325,14 @@ namespace dw {
 class Table: public oof::OOFAwareWidget
 {
 private:
+   struct Cell {
+      core::Widget *widget;
+      int colspanOrig, colspanEff, rowspan;
+   };
+   struct SpanSpace {
+      int startCol, startRow;  // where the cell starts
+   };
+
    struct Child
    {
       enum {
@@ -332,13 +340,8 @@ private:
          SPAN_SPACE  // part of a spanning cell
       } type;
       union {
-         struct {
-            core::Widget *widget;
-            int colspanOrig, colspanEff, rowspan;
-         } cell;
-         struct {
-            int startCol, startRow;  // where the cell starts
-         } spanSpace;
+         struct Cell cell;
+         struct SpanSpace spanSpace;
       };
    };
 

--- a/dw/textblock.cc
+++ b/dw/textblock.cc
@@ -1309,7 +1309,7 @@ void Textblock::drawWord (Line *line, int wordIndex1, int wordIndex2,
          totalWidth += w->size.width;
       }
 
-      char text[l + (drawHyphen ? strlen (hyphenDrawChar) : 0) + 1];
+      char *text = new char[l + (drawHyphen ? strlen (hyphenDrawChar) : 0) + 1];
       int p = 0;
       for (int i = wordIndex1; i <= wordIndex2; i++) {
          const char * t = words->getRef(i)->content.text;
@@ -1325,6 +1325,8 @@ void Textblock::drawWord (Line *line, int wordIndex1, int wordIndex2,
 
       drawWord0 (wordIndex1, wordIndex2, text, totalWidth, drawHyphen,
                  style, view, area, xWidget, yWidgetBase);
+
+      delete[] text;
    }
 }
 
@@ -2066,10 +2068,13 @@ void Textblock::addText (const char *text, size_t len,
 
       // Store hyphen positions.
       int n = 0, totalLenCharRemoved = 0;
-      int partPenaltyIndex[numParts - 1];
-      int partStart[numParts], partEnd[numParts];
-      bool charRemoved[numParts - 1], canBeHyphenated[numParts + 1];
-      bool permDivChar[numParts - 1], unbreakableForMinWidth[numParts - 1];
+      int *partPenaltyIndex = new int[numParts - 1];
+      int *partStart = new int[numParts];
+      int *partEnd = new int[numParts];
+      bool *charRemoved = new bool[numParts - 1];
+      bool *canBeHyphenated = new bool[numParts + 1];
+      bool *permDivChar = new bool[numParts - 1];
+      bool *unbreakableForMinWidth = new bool[numParts - 1];
       canBeHyphenated[0] = canBeHyphenated[numParts] = true;
       partStart[0] = 0;
       partEnd[numParts - 1] = len;
@@ -2134,8 +2139,9 @@ void Textblock::addText (const char *text, size_t len,
 
       // Get text without removed characters, e. g. hyphens.
       const char *textWithoutHyphens;
-      char textWithoutHyphensBuf[len - totalLenCharRemoved];
-      int *breakPosWithoutHyphens, breakPosWithoutHyphensBuf[numParts - 1];
+      char *textWithoutHyphensBuf = new char[len - totalLenCharRemoved];
+      int *breakPosWithoutHyphens;
+      int *breakPosWithoutHyphensBuf = new int[numParts - 1];
 
       if (totalLenCharRemoved == 0) {
          // No removed characters: take original arrays.
@@ -2164,7 +2170,7 @@ void Textblock::addText (const char *text, size_t len,
          PUTCHAR(textWithoutHyphens[i]);
       PRINTF("'\n");
 
-      core::Requisition wordSize[numParts];
+      core::Requisition *wordSize = new core::Requisition[numParts];
       calcTextSizes (textWithoutHyphens, len - totalLenCharRemoved, style,
                      numParts - 1, breakPosWithoutHyphens, wordSize);
 
@@ -2228,6 +2234,17 @@ void Textblock::addText (const char *text, size_t len,
             correctLastWordExtremes ();
          }
       }
+
+      delete[] partPenaltyIndex;
+      delete[] partStart;
+      delete[] partEnd;
+      delete[] charRemoved;
+      delete[] canBeHyphenated;
+      delete[] permDivChar;
+      delete[] unbreakableForMinWidth;
+      delete[] textWithoutHyphensBuf;
+      delete[] breakPosWithoutHyphensBuf;
+      delete[] wordSize;
    }
 
    DBG_OBJ_LEAVE ();

--- a/dw/textblock.cc
+++ b/dw/textblock.cc
@@ -2553,7 +2553,7 @@ void Textblock::addWidget (core::Widget *widget, core::style::Style *style)
 }
 
 /**
- * Add an anchor to the page. "name" is copied, so no strdup is necessary for
+ * Add an anchor to the page. "name" is copied, so no dStrdup is necessary for
  * the caller.
  *
  * Return true on success, and false, when this anchor had already been

--- a/dw/textblock.hh
+++ b/dw/textblock.hh
@@ -8,7 +8,7 @@
 
 // These were used when improved line breaking and hyphenation were implemented.
 // Should be, bit by bit, replaced by RTFL (see ../lout/debug.hh).
-#define PRINTF(fmt, ...)
+#define PRINTF(...)
 #define PUTCHAR(ch)
 
 #ifdef DBG_RTFL

--- a/dw/textblock_iterator.cc
+++ b/dw/textblock_iterator.cc
@@ -113,10 +113,11 @@ void Textblock::TextblockIterator::highlight (int start, int end,
           oldEndIndex != textblock->hlEnd[layer].index ||
           oldEndChar != textblock->hlEnd[layer].nChar)
          textblock->queueDrawRange (index1, index2);
-   } else
+   } else {
       highlightOOF (start, end, layer);
+   }
 
-      DBG_OBJ_LEAVE_O (getWidget ());
+   DBG_OBJ_LEAVE_O (getWidget ());
 }
 
 void Textblock::TextblockIterator::unhighlight (int direction,

--- a/dw/textblock_linebreaking.cc
+++ b/dw/textblock_linebreaking.cc
@@ -1421,7 +1421,7 @@ int Textblock::hyphenateWord (int wordIndex, int *addIndex1)
    if (numBreaks > 0) {
       Word origWord = *hyphenatedWord;
 
-      core::Requisition wordSize[numBreaks + 1];
+      core::Requisition *wordSize = new core::Requisition[numBreaks + 1];
       calcTextSizes (origWord.content.text, strlen (origWord.content.text),
                      origWord.style, numBreaks, breakPos, wordSize);
 
@@ -1506,8 +1506,10 @@ int Textblock::hyphenateWord (int wordIndex, int *addIndex1)
       origWord.spaceStyle->unref ();
 
       free (breakPos);
-   } else
+      delete[] wordSize;
+   } else {
       words->getRef(wordIndex)->flags &= ~Word::CAN_BE_HYPHENATED;
+   }
 
    return numBreaks;
 }

--- a/dw/view.hh
+++ b/dw/view.hh
@@ -48,7 +48,7 @@ public:
     *    Scrolling and Related. Only usesViewport must be
     *    implemented, if it returns false, the other methods
     *    are never called.
-    * ---------------­-----------­-----------------------------
+    * ---------------------------------------------------------
     */
 
    /**

--- a/lout/container.hh
+++ b/lout/container.hh
@@ -251,7 +251,7 @@ protected:
    {
       object::Object *object;
       Node *next;
-      virtual ~Node() = default;
+      virtual ~Node() {};
    };
 
    Node **table;

--- a/lout/misc.cc
+++ b/lout/misc.cc
@@ -32,12 +32,6 @@ namespace misc {
 
 const char *prgName = PRGNAME;
 
-//void init (int argc, char *argv[])
-//{
-//   prgName = dStrdup (argv[0]);
-//}
-
-
 // ------------------
 //    StringBuffer
 // ------------------

--- a/lout/misc.cc
+++ b/lout/misc.cc
@@ -32,10 +32,10 @@ namespace misc {
 
 const char *prgName = PRGNAME;
 
-void init (int argc, char *argv[])
-{
-   prgName = strdup (argv[0]);
-}
+//void init (int argc, char *argv[])
+//{
+//   prgName = dStrdup (argv[0]);
+//}
 
 
 // ------------------

--- a/lout/misc.hh
+++ b/lout/misc.hh
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include "dlib/dlib.h"
 
 namespace lout {
 
@@ -586,7 +587,7 @@ public:
     * A copy is kept in the buffer, so the caller does not have to care
     * about memory management.
     */
-   inline void append(const char *str) { appendNoCopy(strdup(str)); }
+   inline void append(const char *str) { appendNoCopy(dStrdup(str)); }
    inline void appendInt(int n)
    { char buf[32]; sprintf (buf, "%d", n); append (buf); }
    inline void appendPointer(void *p)

--- a/lout/object.cc
+++ b/lout/object.cc
@@ -20,6 +20,7 @@
 
 
 #include "object.hh"
+#include "dlib/dlib.h"
 #include <stdio.h>
 #include <stdint.h>
 #include <config.h>
@@ -83,7 +84,7 @@ const char *Object::toString()
    /** \todo garbage! */
    misc::StringBuffer sb;
    intoStringBuffer(&sb);
-   char *s = strdup(sb.getChars());
+   char *s = dStrdup(sb.getChars());
    return s;
 }
 
@@ -291,7 +292,7 @@ void ConstString::intoStringBuffer(misc::StringBuffer *sb)
 //    String
 // ------------
 
-String::String (const char *str): ConstString (str ? strdup(str) : NULL)
+String::String (const char *str): ConstString (str ? dStrdup(str) : NULL)
 {
 }
 

--- a/src/IO/dpi.c
+++ b/src/IO/dpi.c
@@ -39,6 +39,7 @@
 #include "IO.h"
 #include "Url.h"
 #include "../../dpip/dpip.h"
+#include "dlib/dlib.h"
 
 /* This one is tricky, some sources state it should include the byte
  * for the terminating NULL, and others say it shouldn't. */
@@ -504,12 +505,12 @@ static int Dpi_check_dpid(int num_tries)
 static int Dpi_blocking_start_dpid(void)
 {
    int cst, try = 0,
-       n_tries = 3; /* 3 seconds */
+       n_tries = 12; /* 3 seconds */
 
    /* test the dpid, and wait a bit for it to start if necessary */
    while ((cst = Dpi_check_dpid(n_tries)) == 1) {
       MSG("Dpi_blocking_start_dpid: try %d\n", ++try);
-      sleep(1);
+      dUsleep(250000UL);
    }
    return cst;
 }

--- a/src/IO/dpi.c
+++ b/src/IO/dpi.c
@@ -419,7 +419,7 @@ static int Dpi_read_comm_keys(int *port)
 /**
  * Return a socket file descriptor
  */
-static int Dpi_make_socket_fd()
+static int Dpi_make_socket_fd(void)
 {
    int fd, one = 1, ret = -1;
 
@@ -435,7 +435,7 @@ static int Dpi_make_socket_fd()
  * Make a connection test for a IDS.
  * Return: 1 OK, -1 Not working.
  */
-static int Dpi_check_dpid_ids()
+static int Dpi_check_dpid_ids(void)
 {
    struct sockaddr_in sin;
    const socklen_t sin_sz = sizeof(sin);
@@ -504,12 +504,12 @@ static int Dpi_check_dpid(int num_tries)
 static int Dpi_blocking_start_dpid(void)
 {
    int cst, try = 0,
-       n_tries = 12; /* 3 seconds */
+       n_tries = 3; /* 3 seconds */
 
    /* test the dpid, and wait a bit for it to start if necessary */
    while ((cst = Dpi_check_dpid(n_tries)) == 1) {
       MSG("Dpi_blocking_start_dpid: try %d\n", ++try);
-      usleep(250000); /* 1/4 sec */
+      sleep(1);
    }
    return cst;
 }
@@ -757,7 +757,7 @@ void a_Dpi_ccc(int Op, int Branch, int Dir, ChainLink *Info,
  * Note: currently disabled. It may serve to let the cookies dpi know
  * when to expire session cookies.
  */
-void a_Dpi_dillo_exit()
+void a_Dpi_dillo_exit(void)
 {
 
 }

--- a/src/IO/dpi.c
+++ b/src/IO/dpi.c
@@ -26,6 +26,7 @@
 #include <errno.h>           /* for errno */
 #include <fcntl.h>
 #include <ctype.h>           /* isxdigit */
+#include <stdint.h>
 
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -50,7 +51,6 @@
 #ifndef AF_LOCAL
 #define AF_LOCAL AF_UNIX
 #endif
-
 
 typedef struct {
    int InTag;
@@ -445,7 +445,7 @@ static int Dpi_check_dpid_ids(void)
    /* socket connection test */
    memset(&sin, 0, sizeof(sin));
    sin.sin_family = AF_INET;
-   sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+   sin.sin_addr.s_addr = inet_addr("127.0.0.1");
 
    if (Dpi_read_comm_keys(&dpid_port) != -1) {
       sin.sin_port = htons(dpid_port);
@@ -544,7 +544,7 @@ static int Dpi_get_server_port(const char *server_name)
       sin_sz = sizeof(sin);
       memset(&sin, 0, sizeof(sin));
       sin.sin_family = AF_INET;
-      sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+      sin.sin_addr.s_addr = inet_addr("127.0.0.1");
       sin.sin_port = htons(dpid_port);
       if ((sock_fd = Dpi_make_socket_fd()) == -1 ||
           connect(sock_fd, (struct sockaddr *)&sin, sin_sz) == -1) {
@@ -617,7 +617,7 @@ static int Dpi_connect_socket(const char *server_name)
    /* connect with this server's socket */
    memset(&sin, 0, sizeof(sin));
    sin.sin_family = AF_INET;
-   sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+   sin.sin_addr.s_addr = inet_addr("127.0.0.1");
    sin.sin_port = htons(dpi_port);
 
    if ((sock_fd = Dpi_make_socket_fd()) == -1) {

--- a/src/IO/http.c
+++ b/src/IO/http.c
@@ -234,7 +234,7 @@ void a_Http_connect_done(int fd, bool_t success)
          dFree(info);
       }
    } else {
-      MSG("**** but no luck with fme %p or sd\n", fme);
+      MSG("**** but no luck with fme %p or sd\n", (void *) fme);
    }
 }
 
@@ -1091,7 +1091,7 @@ static void Http_server_remove(Server_t *srv)
    dFree(srv);
 }
 
-static void Http_servers_remove_all()
+static void Http_servers_remove_all(void)
 {
    Server_t *srv;
    SocketData_t *sd;
@@ -1107,7 +1107,7 @@ static void Http_servers_remove_all()
    dList_free(servers);
 }
 
-static void Http_fd_map_remove_all()
+static void Http_fd_map_remove_all(void)
 {
    FdMapEntry_t *fme;
    int i, n = dList_length(fd_map);

--- a/src/IO/mime.c
+++ b/src/IO/mime.c
@@ -94,7 +94,7 @@ static Viewer_t Mime_major_type_fetch(const char *Key, uint_t Size)
 /**
  * Initializes Mime module and, sets the supported Mime types.
  */
-void a_Mime_init()
+void a_Mime_init(void)
 {
 #ifdef ENABLE_GIF
    Mime_add_minor_type("image/gif", a_Dicache_gif_image);

--- a/src/IO/tls.c
+++ b/src/IO/tls.c
@@ -28,7 +28,7 @@
 /**
  * Initialize TLS library.
  */
-void a_Tls_init()
+void a_Tls_init(void)
 {
 #if ! defined(ENABLE_TLS)
    MSG("TLS: Disabled at compilation time.\n");

--- a/src/IO/tls.h
+++ b/src/IO/tls.h
@@ -31,13 +31,13 @@ extern "C" {
 #define TLS_CONNECT_NOT_YET 0
 #define TLS_CONNECT_READY 1
 
-void a_Tls_init();
+void a_Tls_init(void);
 int a_Tls_certificate_is_clean(const DilloUrl *url);
 int a_Tls_connect_ready(const DilloUrl *url);
 void a_Tls_reset_server_state(const DilloUrl *url);
 void a_Tls_connect(int fd, const DilloUrl *url);
 void *a_Tls_connection(int fd);
-void a_Tls_freeall();
+void a_Tls_freeall(void);
 void a_Tls_close_by_fd(int fd);
 int a_Tls_read(void *conn, void *buf, size_t len);
 int a_Tls_write(void *conn, void *buf, size_t len);

--- a/src/IO/tls_mbedtls.h
+++ b/src/IO/tls_mbedtls.h
@@ -21,13 +21,13 @@ extern "C" {
 
 #include "../url.h"
 
-void a_Tls_mbedtls_init();
+void a_Tls_mbedtls_init(void);
 int a_Tls_mbedtls_certificate_is_clean(const DilloUrl *url);
 int a_Tls_mbedtls_connect_ready(const DilloUrl *url);
 void a_Tls_mbedtls_reset_server_state(const DilloUrl *url);
 void a_Tls_mbedtls_connect(int fd, const DilloUrl *url);
 void *a_Tls_mbedtls_connection(int fd);
-void a_Tls_mbedtls_freeall();
+void a_Tls_mbedtls_freeall(void);
 void a_Tls_mbedtls_close_by_fd(int fd);
 int a_Tls_mbedtls_read(void *conn, void *buf, size_t len);
 int a_Tls_mbedtls_write(void *conn, void *buf, size_t len);

--- a/src/IO/tls_openssl.c
+++ b/src/IO/tls_openssl.c
@@ -199,7 +199,7 @@ static void Tls_info_cb(const SSL *ssl, int where, int ret)
  * abysmal openssl documentation, this was worked out from reading discussion
  * on the web and then reading openssl source to see what it normally does.
  */
-static void Tls_load_certificates()
+static void Tls_load_certificates(void)
 {
    /* curl-7.37.1 says that the following bundle locations are used on "Debian
     * systems", "Redhat and Mandriva", "old(er) Redhat", "FreeBSD", and
@@ -1338,7 +1338,7 @@ void a_Tls_openssl_close_by_fd(int fd)
    }
 }
 
-static void Tls_servers_freeall()
+static void Tls_servers_freeall(void)
 {
    if (servers) {
       Server_t *s;
@@ -1353,7 +1353,7 @@ static void Tls_servers_freeall()
    }
 }
 
-static void Tls_fd_map_remove_all()
+static void Tls_fd_map_remove_all(void)
 {
    if (fd_map) {
       FdMapEntry_t *fme;

--- a/src/IO/tls_openssl.h
+++ b/src/IO/tls_openssl.h
@@ -31,13 +31,13 @@ extern "C" {
 
 #include "../url.h"
 
-void a_Tls_openssl_init();
+void a_Tls_openssl_init(void);
 int a_Tls_openssl_certificate_is_clean(const DilloUrl *url);
 int a_Tls_openssl_connect_ready(const DilloUrl *url);
 void a_Tls_openssl_reset_server_state(const DilloUrl *url);
 void a_Tls_openssl_connect(int fd, const DilloUrl *url);
 void *a_Tls_openssl_connection(int fd);
-void a_Tls_openssl_freeall();
+void a_Tls_openssl_freeall(void);
 void a_Tls_openssl_close_by_fd(int fd);
 int a_Tls_openssl_read(void *conn, void *buf, size_t len);
 int a_Tls_openssl_write(void *conn, void *buf, size_t len);

--- a/src/auth.c
+++ b/src/auth.c
@@ -17,7 +17,7 @@
  */
 
 
-#include <ctype.h> /* iscntrl */
+#include <ctype.h> /* iscntrl, isascii */
 #include "auth.h"
 #include "msg.h"
 #include "misc.h"
@@ -61,7 +61,7 @@ void a_Auth_init(void)
    auth_hosts = dList_new(1);
 }
 
-static AuthParse_t *Auth_parse_new()
+static AuthParse_t *Auth_parse_new(void)
 {
    AuthParse_t *auth_parse = dNew(AuthParse_t, 1);
    auth_parse->ok = 0;
@@ -105,7 +105,7 @@ static int Auth_path_is_inside(const char *path1, const char *path2, int len)
 static int Auth_is_token_char(char c)
 {
    const char *invalid = "\"()<>@,;:\\[]?=/{} \t";
-   return (!isascii(c) || strchr(invalid, c) || iscntrl((uchar_t)c)) ? 0 : 1;
+   return (!d_isascii(c) || strchr(invalid, c) || iscntrl((uchar_t)c)) ? 0 : 1;
 }
 
 /**
@@ -231,7 +231,7 @@ static int Auth_parse_basic_challenge_cb(AuthParse_t *auth_parse, char *token,
 {
    if (dStrAsciiCasecmp("realm", token) == 0) {
       if (!auth_parse->realm)
-         auth_parse->realm = strdup(value);
+         auth_parse->realm = dStrdup(value);
       return 0; /* end parsing */
    } else
       MSG("Auth_parse_basic_challenge_cb: Ignoring unknown parameter: %s = "
@@ -245,13 +245,13 @@ static int Auth_parse_digest_challenge_cb(AuthParse_t *auth_parse, char *token,
    const char *const fn = "Auth_parse_digest_challenge_cb";
 
    if (!dStrAsciiCasecmp("realm", token) && !auth_parse->realm)
-      auth_parse->realm = strdup(value);
+      auth_parse->realm = dStrdup(value);
    else if (!strcmp("domain", token) && !auth_parse->domain)
-      auth_parse->domain = strdup(value);
+      auth_parse->domain = dStrdup(value);
    else if (!strcmp("nonce", token)  && !auth_parse->nonce)
-      auth_parse->nonce = strdup(value);
+      auth_parse->nonce = dStrdup(value);
    else if (!strcmp("opaque", token) && !auth_parse->opaque)
-      auth_parse->opaque = strdup(value);
+      auth_parse->opaque = dStrdup(value);
    else if (strcmp("stale", token) == 0) {
       if (dStrAsciiCasecmp("true", value) == 0)
          auth_parse->stale = 1;

--- a/src/bw.c
+++ b/src/bw.c
@@ -44,7 +44,7 @@ void a_Bw_init(void)
  * Create a new browser window and return it.
  * (the new window is stored in browser_window[])
  */
-BrowserWindow *a_Bw_new()
+BrowserWindow *a_Bw_new(void)
 {
    BrowserWindow *bw;
 
@@ -302,7 +302,7 @@ void a_Bw_cleanup(BrowserWindow *bw)
 
 /*--------------------------------------------------------------------------*/
 
-int a_Bw_num()
+int a_Bw_num(void)
 {
    return num_bws;
 }

--- a/src/bw.h
+++ b/src/bw.h
@@ -81,10 +81,10 @@ extern "C" {
 
 
 void a_Bw_init(void);
-BrowserWindow *a_Bw_new();
+BrowserWindow *a_Bw_new(void);
 void a_Bw_free(BrowserWindow *bw);
 BrowserWindow *a_Bw_get(int i);
-int a_Bw_num();
+int a_Bw_num(void);
 
 void a_Bw_add_client(BrowserWindow *bw, int Key, int Root);
 int a_Bw_remove_client(BrowserWindow *bw, int ClientKey);

--- a/src/cache.c
+++ b/src/cache.c
@@ -1359,9 +1359,10 @@ static CacheEntry_t *Cache_process_queue(CacheEntry_t *entry)
 /**
  * Callback function for Cache_delayed_process_queue.
  */
-static void Cache_delayed_process_queue_callback()
+static void Cache_delayed_process_queue_callback(void *ptr)
 {
    CacheEntry_t *entry;
+   (void) ptr; /* Unused */
 
    while ((entry = (CacheEntry_t *)dList_nth_data(DelayedQueue, 0))) {
       Cache_ref_data(entry);

--- a/src/cookies.c
+++ b/src/cookies.c
@@ -2,7 +2,7 @@
  * File: cookies.c
  *
  * Copyright 2001 Lars Clausen   <lrclause@cs.uiuc.edu>
- *                Jörgen Viksell <jorgen.viksell@telia.com>
+ *                JÃ¶rgen Viksell <jorgen.viksell@telia.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -132,7 +132,7 @@ void a_Cookies_init(void)
 /**
  * Flush cookies to disk and free all the memory allocated.
  */
-void a_Cookies_freeall()
+void a_Cookies_freeall(void)
 {
 }
 

--- a/src/css.cc
+++ b/src/css.cc
@@ -91,7 +91,7 @@ void CssPropertyList::apply (CssPropertyList *props) {
       if (props->ownerOfStrings &&
           (getRef (i)->type == CSS_TYPE_STRING ||
            getRef (i)->type == CSS_TYPE_SYMBOL))
-         value.strVal = strdup(value.strVal);
+         value.strVal = dStrdup(value.strVal);
 
       props->set ((CssPropertyName) getRef (i)->name,
                   (CssValueType) getRef (i)->type,

--- a/src/decode.c
+++ b/src/decode.c
@@ -304,7 +304,7 @@ DecodeTransfer *a_Decode_transfer_init(const char *format)
    return dc;
 }
 
-static Decode *Decode_content_init_common()
+static Decode *Decode_content_init_common(void)
 {
    z_stream *zs = dNew(z_stream, 1);
    Decode *dc = dNew(Decode, 1);

--- a/src/dialog.cc
+++ b/src/dialog.cc
@@ -184,7 +184,7 @@ const char *a_Dialog_input(const char *title, const char *msg)
     if (!pm) {
        int n_it = dList_length(prefs.search_urls);
        pm = new Fl_Menu_Item[n_it+1];
-       memset(pm, '\0', sizeof(Fl_Menu_Item[n_it+1]));
+       memset(pm, '\0', sizeof(*pm));
        for (int i = 0, j = 0; i < n_it; i++) {
           char *label, *url, *source;
           source = (char *)dList_nth_data(prefs.search_urls, i);

--- a/src/dialog.cc
+++ b/src/dialog.cc
@@ -184,7 +184,7 @@ const char *a_Dialog_input(const char *title, const char *msg)
     if (!pm) {
        int n_it = dList_length(prefs.search_urls);
        pm = new Fl_Menu_Item[n_it+1];
-       memset(pm, '\0', sizeof(*pm));
+       memset(pm, '\0', (n_it + 1) * sizeof(Fl_Menu_Item));
        for (int i = 0, j = 0; i < n_it; i++) {
           char *label, *url, *source;
           source = (char *)dList_nth_data(prefs.search_urls, i);

--- a/src/dialog.cc
+++ b/src/dialog.cc
@@ -32,6 +32,7 @@
 #include "dialog.hh"
 #include "misc.h"
 #include "prefs.h"
+#include "dlib/dlib.h"
 
 /*
  * Local Data
@@ -190,7 +191,7 @@ const char *a_Dialog_input(const char *title, const char *msg)
           source = (char *)dList_nth_data(prefs.search_urls, i);
           if (!source || a_Misc_parse_search_url(source, &label, &url) < 0)
              continue;
-          pm[j++].label(FL_NORMAL_LABEL, strdup(label));
+          pm[j++].label(FL_NORMAL_LABEL, dStrdup(label));
        }
     }
     ch->tooltip("Select search engine");

--- a/src/dillo.cc
+++ b/src/dillo.cc
@@ -125,6 +125,8 @@ static void raw_sigchld2(int signum)
    pid_t pid;
    int status;
 
+   (void) signum; /* Unused */
+
    while (1) {
       pid = waitpid(-1, &status, WNOHANG);
       if (pid > 0) {
@@ -141,7 +143,6 @@ static void raw_sigchld2(int signum)
          break;
       }
    }
-   ++signum; /* compiler happiness */
 }
 
 /**

--- a/src/dns.c
+++ b/src/dns.c
@@ -288,17 +288,7 @@ static void *Dns_server(void *data)
 
    if (error != 0) {
       dns_server[channel].status = error;
-      if (error == EAI_NONAME)
-         MSG("DNS error: HOST_NOT_FOUND\n");
-      else if (error == EAI_AGAIN)
-         MSG("DNS error: TRY_AGAIN\n");
-#ifdef EAI_NODATA
-      /* Some FreeBSD don't have this anymore */
-      else if (error == EAI_NODATA)
-         MSG("DNS error: NO_ADDRESS\n");
-#endif
-      else if (h_errno == EAI_FAIL)
-         MSG("DNS error: NO_RECOVERY\n");
+      MSG("DNS error: %s\n", gai_strerror(error));
    } else {
       Dns_note_hosts(hosts, res0);
       dns_server[channel].status = 0;

--- a/src/form.cc
+++ b/src/form.cc
@@ -1720,9 +1720,8 @@ void DilloHtmlInput::activate(DilloHtmlForm *form, int num_entry_fields,
    case DILLO_HTML_INPUT_PASSWORD:
       if (!(prefs.enterpress_forces_submit || num_entry_fields == 1)) {
          break;
-      } else {
-         /* fall through */
       }
+      /* fallthrough */
    case DILLO_HTML_INPUT_SUBMIT:
    case DILLO_HTML_INPUT_BUTTON_SUBMIT:
    case DILLO_HTML_INPUT_IMAGE:

--- a/src/form.cc
+++ b/src/form.cc
@@ -19,6 +19,7 @@
 #include "dw/core.hh"
 #include "dw/textblock.hh"
 
+#include "dlib/dlib.h"
 #include "misc.h"
 #include "msg.h"
 #include "prefs.h"
@@ -829,7 +830,7 @@ void Html_tag_open_optgroup(DilloHtml *html, const char *tag, int tagsize)
 
       if (!label) {
          BUG_MSG("<optgroup> requires label attribute.");
-         label = strdup("");
+         label = dStrdup("");
       }
 
       DilloHtmlOptgroup *opt =

--- a/src/gif.c
+++ b/src/gif.c
@@ -975,7 +975,7 @@ static size_t Gif_process_bytes(DilloGif *gif, const uchar_t *ibuf,
       ibuf += mysize;
       if (gif->state != 1)
          break;
-
+      /* fallthrough */
    case 1:
       mysize = Gif_get_descriptor(gif, Buf, ibuf, tmp_bufsize);
       if (!mysize)
@@ -983,7 +983,7 @@ static size_t Gif_process_bytes(DilloGif *gif, const uchar_t *ibuf,
       tmp_bufsize -= mysize;
       ibuf += mysize;
       gif->state = 2;
-
+      /* fallthrough */
    case 2:
       /* Ok, this loop construction looks weird.  It implements the <Data>* of
        * the GIF grammar.  All sorts of stuff is allocated to set up for the
@@ -996,7 +996,7 @@ static size_t Gif_process_bytes(DilloGif *gif, const uchar_t *ibuf,
       ibuf += mysize;
       if (gif->state != 3)
          break;
-
+      /* fallthrough */
    case 3:
       /* get an image byte */
       /* The users sees all of this stuff */
@@ -1005,7 +1005,7 @@ static size_t Gif_process_bytes(DilloGif *gif, const uchar_t *ibuf,
          break;
       ibuf += mysize;
       tmp_bufsize -= mysize;
-
+      /* fallthrough */
    default:
       /* error - just consume all input */
       tmp_bufsize = 0;

--- a/src/history.c
+++ b/src/history.c
@@ -33,7 +33,7 @@ static int history_size_max = 16;
 /**
  * Debug procedure.
  */
-void History_show()
+void History_show(void)
 {
    int i;
 
@@ -149,7 +149,7 @@ void a_History_set_title_by_url(const DilloUrl *url, const char *title)
 /**
  * Free all the memory used by this module
  */
-void a_History_freeall()
+void a_History_freeall(void)
 {
    int i;
 

--- a/src/hsts.c
+++ b/src/hsts.c
@@ -52,7 +52,7 @@ static void Hsts_free_policy(HstsData_t *p)
    dFree(p);
 }
 
-void a_Hsts_freeall()
+void a_Hsts_freeall(void)
 {
    if (prefs.http_strict_transport_security) {
       HstsData_t *policy;

--- a/src/html.cc
+++ b/src/html.cc
@@ -4130,6 +4130,7 @@ static void Html_process_tag(DilloHtml *html, char *tag, int tagsize)
          html->ReqTagClose = true;
 
       /* Don't break! Open tags may also close themselves */
+      /* fallthrough */
 
    default:
       /* Close function */

--- a/src/html.cc
+++ b/src/html.cc
@@ -1486,10 +1486,10 @@ static int
       int i;
 
       for (i = 0; val[i]; ++i)
-         if (!isascii(val[i]) || !(isalnum(val[i]) || strchr(":_.-", val[i])))
+         if (!d_isascii(val[i]) || !(isalnum(val[i]) || strchr(":_.-", val[i])))
             break;
 
-      if (val[i] || !(isascii(val[0]) && isalpha(val[0])))
+      if (val[i] || !(d_isascii(val[0]) && isalpha(val[0])))
          BUG_MSG("%s attribute value \"%s\" is not of the form "
                  "'[A-Za-z][A-Za-z0-9:_.-]*'.", attrname, val);
 

--- a/src/jpeg.c
+++ b/src/jpeg.c
@@ -119,13 +119,9 @@ static void Jpeg_close(DilloJpeg *jpeg, CacheClient_t *Client)
    Jpeg_free(jpeg);
 }
 
-/*
- * The proper signature is:
- *    static void init_source(j_decompress_ptr cinfo)
- * (declaring it with no parameter avoids a compiler warning)
- */
-static void init_source()
+static void init_source(struct jpeg_decompress_struct *p)
 {
+   (void) p; /* unused */
 }
 
 static boolean fill_input_buffer(j_decompress_ptr cinfo)
@@ -181,8 +177,9 @@ static void skip_input_data(j_decompress_ptr cinfo, long num_bytes)
  *    static void term_source(j_decompress_ptr cinfo)
  * (declaring it with no parameter avoids a compiler warning)
  */
-static void term_source()
+static void term_source(struct jpeg_decompress_struct *p)
 {
+   (void) p; /* unused */
 }
 
 void *a_Jpeg_new(DilloImage *Image, DilloUrl *url, int version)

--- a/src/md5.c
+++ b/src/md5.c
@@ -63,6 +63,7 @@
 
 #include "md5.h"
 #include <string.h>
+#include <stdint.h>
 
 #undef BYTE_ORDER	/* 1 = big-endian, -1 = little-endian, 0 = unknown */
 #ifdef ARCH_IS_BIG_ENDIAN
@@ -171,7 +172,7 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 	     * On little-endian machines, we can process properly aligned
 	     * data without copying it.
 	     */
-	    if (!((data - (const md5_byte_t *)0) & 3)) {
+	    if (((uintptr_t) data & 3) == 0) {
 		/* data are properly aligned */
 		X = (const md5_word_t *)data;
 	    } else {

--- a/src/menu.cc
+++ b/src/menu.cc
@@ -397,7 +397,7 @@ void a_Menu_page_popup(BrowserWindow *bw, const DilloUrl *url,
 
    if (cssUrls && cssUrls->size () > 0) {
       stylesheets = new Fl_Menu_Item[cssUrls->size() + 1];
-      memset(stylesheets, '\0', sizeof(*stylesheets));
+      memset(stylesheets, '\0', (cssUrls->size() + 1) * sizeof(Fl_Menu_Item));
 
       for (j = 0; j < cssUrls->size(); j++) {
          DilloUrl *url = cssUrls->get(j);
@@ -638,7 +638,7 @@ void a_Menu_history_popup(BrowserWindow *bw, int x, int y, int direction)
       ;
 
    pm = new Fl_Menu_Item[n + 1];
-   memset(pm, '\0', sizeof(*pm));
+   memset(pm, '\0', (n + 1) * sizeof(Fl_Menu_Item));
 
    for (i = 0; i < n; i++) {
       pm[i].label(FL_NORMAL_LABEL, a_History_get_title(history_list[i], 1));

--- a/src/menu.cc
+++ b/src/menu.cc
@@ -397,7 +397,7 @@ void a_Menu_page_popup(BrowserWindow *bw, const DilloUrl *url,
 
    if (cssUrls && cssUrls->size () > 0) {
       stylesheets = new Fl_Menu_Item[cssUrls->size() + 1];
-      memset(stylesheets, '\0', sizeof(Fl_Menu_Item[cssUrls->size() + 1]));
+      memset(stylesheets, '\0', sizeof(*stylesheets));
 
       for (j = 0; j < cssUrls->size(); j++) {
          DilloUrl *url = cssUrls->get(j);
@@ -638,7 +638,7 @@ void a_Menu_history_popup(BrowserWindow *bw, int x, int y, int direction)
       ;
 
    pm = new Fl_Menu_Item[n + 1];
-   memset(pm, '\0', sizeof(Fl_Menu_Item[n + 1]));
+   memset(pm, '\0', sizeof(*pm));
 
    for (i = 0; i < n; i++) {
       pm[i].label(FL_NORMAL_LABEL, a_History_get_title(history_list[i], 1));

--- a/src/misc.c
+++ b/src/misc.c
@@ -222,13 +222,13 @@ void a_Misc_parse_content_type(const char *type, char **major, char **minor,
    if (!(str = type))
       return;
 
-   for (s = str; *s && isascii((uchar_t)*s) && !iscntrl((uchar_t)*s) &&
+   for (s = str; *s && d_isascii((uchar_t)*s) && !iscntrl((uchar_t)*s) &&
         !strchr(tspecials_space, *s); s++) ;
    if (major)
       *major = dStrndup(str, s - str);
 
    if (*s == '/') {
-      for (str = ++s; *s && isascii((uchar_t)*s) && !iscntrl((uchar_t)*s) &&
+      for (str = ++s; *s && d_isascii((uchar_t)*s) && !iscntrl((uchar_t)*s) &&
            !strchr(tspecials_space, *s); s++) ;
       if (minor)
          *minor = dStrndup(str, s - str);

--- a/src/misc.h
+++ b/src/misc.h
@@ -8,6 +8,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#define d_isascii(c)  (((c) & ~0x7f) == 0) 
 
 char *a_Misc_escape_chars(const char *str, const char *esc_set);
 int a_Misc_expand_tabs(char **start, char *end, char *buf, int buflen);

--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -1288,11 +1288,11 @@ static void nsvg__initPaint(NSVGcachedPaint* cache, NSVGpaint* paint, float opac
 	cache->type = paint->type;
 
 	if (paint->type == NSVG_PAINT_COLOR) {
-		cache->colors[0] = nsvg__applyOpacity(paint->color, opacity);
+		cache->colors[0] = nsvg__applyOpacity(paint->v.color, opacity);
 		return;
 	}
 
-	grad = paint->gradient;
+	grad = paint->v.gradient;
 
 	cache->spread = grad->spread;
 	memcpy(cache->xform, grad->xform, sizeof(float)*6);

--- a/src/nav.c
+++ b/src/nav.c
@@ -555,7 +555,7 @@ static void Nav_save_cb(int Op, CacheClient_t *Client)
       a_UIcmd_set_msg(Web->bw, "File saved (%d Bytes)", st.st_size);
    } else {
       if ((Bytes = Client->BufSize - Web->SavedBytes) > 0) {
-         Bytes = fwrite(Client->Buf + Web->SavedBytes, 1, Bytes, Web->stream);
+         Bytes = fwrite((char *) Client->Buf + Web->SavedBytes, 1, Bytes, Web->stream);
          Web->SavedBytes += Bytes;
       }
    }

--- a/src/timeout.hh
+++ b/src/timeout.hh
@@ -9,7 +9,7 @@ typedef void (*TimeoutCb_t)(void *data);
 
 void a_Timeout_add(float t, TimeoutCb_t cb, void *cbdata);
 void a_Timeout_repeat(float t, TimeoutCb_t cb, void *cbdata);
-void a_Timeout_remove();
+void a_Timeout_remove(void);
 
 
 #ifdef __cplusplus

--- a/src/tipwin.cc
+++ b/src/tipwin.cc
@@ -27,6 +27,7 @@
 
 #include "prefs.h"
 #include "tipwin.hh"
+#include "dlib/dlib.h"
 
 /*
  * Forward declarations
@@ -132,7 +133,7 @@ TipWinButton::TipWinButton(int x, int y, int w, int h, const char *l) :
     Fl_Button(x, y, w, h, l)
 {
    tipwin = my_tipwin();
-   mytooltip = strdup("empty");
+   mytooltip = dStrdup("empty");
 }
 
 TipWinButton::~TipWinButton(void)
@@ -161,7 +162,7 @@ int TipWinButton::handle(int e)
 void TipWinButton::set_tooltip(const char *s)
 {
    free(mytooltip);
-   mytooltip = strdup(s);
+   mytooltip = dStrdup(s);
 }
 
 
@@ -209,7 +210,7 @@ TipWinInput::TipWinInput (int x, int y, int w, int h, const char *l) :
    Fl_Input(x,y,w,h,l)
 {
    tipwin = my_tipwin();
-   mytooltip = strdup("empty");
+   mytooltip = dStrdup("empty");
 }
 
 TipWinInput::~TipWinInput(void)
@@ -239,6 +240,6 @@ int TipWinInput::handle(int e)
 void TipWinInput::set_tooltip(const char *s)
 {
    free(mytooltip);
-   mytooltip = strdup(s);
+   mytooltip = dStrdup(s);
 }
 

--- a/src/uicmd.cc
+++ b/src/uicmd.cc
@@ -1268,7 +1268,7 @@ void a_UIcmd_view_page_source(BrowserWindow *bw, const DilloUrl *url)
    Dstr *dstr_url;
    DilloUrl *vs_url;
    static int post_id = 0;
-   char tag[8];
+   char tag[16];
    const char *content_type = a_Nav_get_content_type(url);
 
    a_Misc_parse_content_type(content_type, &major, NULL, NULL);
@@ -1281,7 +1281,7 @@ void a_UIcmd_view_page_source(BrowserWindow *bw, const DilloUrl *url)
       if (URL_FLAGS(url) & URL_Post) {
          /* append a custom string to differentiate POST URLs */
          post_id = (post_id < 9999) ? post_id + 1 : 0;
-         snprintf(tag, 8, "_%.4d", post_id);
+         snprintf(tag, 16, "_%.4d", post_id);
          dStr_append(dstr_url, tag);
       }
       vs_url = a_Url_new(dstr_url->str, NULL);

--- a/src/uicmd.cc
+++ b/src/uicmd.cc
@@ -46,6 +46,7 @@
 #include "msg.h"
 #include "prefs.h"
 #include "misc.h"
+#include "dlib/dlib.h"
 
 #include "dw/fltkviewport.hh"
 
@@ -704,7 +705,7 @@ static char *UIcmd_find_search_str(const char *str)
       for (p = 0; p < dList_length(prefs.search_urls); p++) {
          const char *search =
             (const char *)dList_nth_data(prefs.search_urls, p);
-         if (search && strncasecmp(str, search, len) == 0) {
+         if (search && dStrnAsciiCasecmp(str, search, len) == 0) {
             prefs.search_url_idx = p;
             url = UIcmd_make_search_str(str + len + 1);
             break;

--- a/src/uicmd.hh
+++ b/src/uicmd.hh
@@ -44,7 +44,7 @@ void a_UIcmd_stop(void *vbw);
 void a_UIcmd_tools(void *vbw, int x, int y);
 void a_UIcmd_save_link(BrowserWindow *bw, const DilloUrl *url);
 void a_UIcmd_open_file(void *vbw);
-const char *a_UIcmd_select_file();
+const char *a_UIcmd_select_file(void);
 void a_UIcmd_search_dialog(void *vbw);
 const char *a_UIcmd_get_passwd(const char *user);
 void a_UIcmd_book(void *vbw);

--- a/src/url.c
+++ b/src/url.c
@@ -48,6 +48,7 @@
 
 #include "url.h"
 #include "hsts.h"
+#include "misc.h"
 #include "msg.h"
 
 static const char *HEX = "0123456789ABCDEF";
@@ -627,7 +628,7 @@ char *a_Url_encode_hex_str(const char *str)
    newstr = dNew(char, 6*strlen(str)+1);
 
    for (c = newstr; *str; str++)
-      if ((dIsalnum(*str) && isascii(*str)) || strchr(verbatim, *str))
+      if ((dIsalnum(*str) && d_isascii(*str)) || strchr(verbatim, *str))
          *c++ = *str;
       else if (*str == ' ')
          *c++ = '+';

--- a/test/dw/Makefile.am
+++ b/test/dw/Makefile.am
@@ -10,6 +10,7 @@ LDADD = \
 	$(top_builddir)/dw/libDw-fltk.a \
 	$(top_builddir)/dw/libDw-core.a \
 	$(top_builddir)/lout/liblout.a \
+	$(top_builddir)/dlib/libDlib.a \
 	@LIBFLTK_LIBS@ @LIBX11_LIBS@
 
 check_PROGRAMS = \

--- a/test/dw/dw_anchors_test.cc
+++ b/test/dw/dw_anchors_test.cc
@@ -24,6 +24,7 @@
 #include <FL/Fl_Window.H>
 #include <FL/Fl.H>
 
+#include "dlib/dlib.h"
 #include "dw/core.hh"
 #include "dw/fltkcore.hh"
 #include "dw/fltkviewport.hh"
@@ -111,7 +112,7 @@ int main(int argc, char **argv)
       char buf[16];
       strcpy (buf, numbers[i]);
       buf[0] = lout::misc::AsciiToupper (buf[0]);
-      buttonLabel[i] = strdup(buf);
+      buttonLabel[i] = dStrdup(buf);
       Fl_Button *button = new Fl_Button(0, 20 * i, 50, 20, buttonLabel[i]);
       button->callback (anchorCallback, (void*)(long)i);
       button->when (FL_WHEN_RELEASE);

--- a/test/dw/form.cc
+++ b/test/dw/form.cc
@@ -20,6 +20,7 @@
 
 
 #include "form.hh"
+#include "dlib/dlib.h"
 
 namespace form {
 
@@ -27,7 +28,7 @@ using namespace dw::core::ui;
 
 Form::ResourceDecorator::ResourceDecorator (const char *name)
 {
-   this->name = strdup (name);
+   this->name = dStrdup (name);
 }
 
 Form::ResourceDecorator::~ResourceDecorator ()
@@ -58,7 +59,7 @@ Form::RadioButtonResourceDecorator::RadioButtonResourceDecorator
       n++;
    this->values = new const char*[n + 1];
    for (int i = 0; i < n; i++)
-      this->values[i] = strdup (values[i]);
+      this->values[i] = dStrdup (values[i]);
    this->values[n] = 0;
 }
 
@@ -108,7 +109,7 @@ Form::SelectionResourceDecorator::SelectionResourceDecorator
       n++;
    this->values = new const char*[n + 1];
    for(int i = 0; i < n; i++)
-      this->values[i] = strdup (values[i]);
+      this->values[i] = dStrdup (values[i]);
    this->values[n] = 0;
 }
 
@@ -153,8 +154,8 @@ Form::FormClickedReceiver::FormClickedReceiver (Form *form, const char *name,
                                           const char *value)
 {
    this->form = form;
-   this->name = strdup (name);
-   this->value = strdup (value);
+   this->name = dStrdup (name);
+   this->value = dStrdup (value);
 }
 
 Form::FormClickedReceiver::~FormClickedReceiver ()

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -27,8 +27,14 @@ EXTRA_DIST = \
 	hyph-de.pat
 
 containers_SOURCES = containers.cc
+containers_LDADD = \
+	$(top_builddir)/lout/liblout.a \
+	$(top_builddir)/dlib/libDlib.a
 notsosimplevector_SOURCES = notsosimplevector.cc
 identity_SOURCES = identity.cc
+identity_LDADD = \
+	$(top_builddir)/lout/liblout.a \
+	$(top_builddir)/dlib/libDlib.a
 cookies_SOURCES = cookies.c
 cookies_LDADD = \
 	$(top_builddir)/dpip/libDpip.a \
@@ -36,6 +42,7 @@ cookies_LDADD = \
 shapes_SOURCES = shapes.cc
 shapes_LDADD = \
 	$(top_builddir)/dw/libDw-core.a \
+	$(top_builddir)/dlib/libDlib.a \
 	$(top_builddir)/lout/liblout.a
 unicode_test_SOURCES = unicode_test.cc
 unicode_test_LDADD = \
@@ -47,6 +54,7 @@ liang_LDADD = \
 	$(top_builddir)/dw/libDw-fltk.a \
 	$(top_builddir)/dw/libDw-core.a \
 	$(top_builddir)/lout/liblout.a \
+	$(top_builddir)/dlib/libDlib.a \
 	@LIBFLTK_LIBS@ @LIBX11_LIBS@
 trie_SOURCES = trie.cc
 trie_LDADD = \
@@ -54,4 +62,5 @@ trie_LDADD = \
 	$(top_builddir)/dw/libDw-fltk.a \
 	$(top_builddir)/dw/libDw-core.a \
 	$(top_builddir)/lout/liblout.a \
+	$(top_builddir)/dlib/libDlib.a \
 	@LIBFLTK_LIBS@ @LIBX11_LIBS@

--- a/test/unit/cookies.c
+++ b/test/unit/cookies.c
@@ -277,12 +277,12 @@ static int Dpi_check_dpid(int num_tries)
 static int Dpi_blocking_start_dpid(void)
 {
    int cst, try = 0,
-       n_tries = 12; /* 3 seconds */
+       n_tries = 3; /* 3 seconds */
 
    /* test the dpid, and wait a bit for it to start if necessary */
    while ((cst = Dpi_check_dpid(n_tries)) == 1) {
       MSG("Dpi_blocking_start_dpid: try %d\n", ++try);
-      usleep(250000); /* 1/4 sec */
+      sleep(1); /* 1/4 sec */
    }
    return cst;
 }

--- a/test/unit/cookies.c
+++ b/test/unit/cookies.c
@@ -277,12 +277,12 @@ static int Dpi_check_dpid(int num_tries)
 static int Dpi_blocking_start_dpid(void)
 {
    int cst, try = 0,
-       n_tries = 3; /* 3 seconds */
+       n_tries = 12; /* 3 seconds */
 
    /* test the dpid, and wait a bit for it to start if necessary */
    while ((cst = Dpi_check_dpid(n_tries)) == 1) {
       MSG("Dpi_blocking_start_dpid: try %d\n", ++try);
-      sleep(1); /* 1/4 sec */
+      dUsleep(250000U); /* 1/4 sec */
    }
    return cst;
 }

--- a/test/unit/cookies.c
+++ b/test/unit/cookies.c
@@ -148,7 +148,7 @@ static int Dpi_check_dpid_ids()
    /* socket connection test */
    memset(&sin, 0, sizeof(sin));
    sin.sin_family = AF_INET;
-   sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+   sin.sin_addr.s_addr = inet_addr("127.0.0.1");
 
    if (Dpi_read_comm_keys(&dpid_port) != -1) {
       sin.sin_port = htons(dpid_port);
@@ -317,7 +317,7 @@ static int Dpi_get_server_port(const char *server_name)
       sin_sz = sizeof(sin);
       memset(&sin, 0, sizeof(sin));
       sin.sin_family = AF_INET;
-      sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+      sin.sin_addr.s_addr = inet_addr("127.0.0.1");
       sin.sin_port = htons(dpid_port);
       if ((sock_fd = Dpi_make_socket_fd()) == -1 ||
           connect(sock_fd, (struct sockaddr *)&sin, sin_sz) == -1) {
@@ -385,7 +385,7 @@ static int Dpi_connect_socket(const char *server_name)
    /* connect with this server's socket */
    memset(&sin, 0, sizeof(sin));
    sin.sin_family = AF_INET;
-   sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+   sin.sin_addr.s_addr = inet_addr("127.0.0.1");
    sin.sin_port = htons(dpi_port);
 
    if ((sock_fd = Dpi_make_socket_fd()) == -1) {

--- a/test/unit/unicode_test.cc
+++ b/test/unit/unicode_test.cc
@@ -32,7 +32,7 @@ int main (int argc, char *argv[])
 
    // not 0-terminated; copy from 0-terminated
    int t2len = strlen (t1);
-   char t2[t2len];
+   char *t2 = new char[t2len];
    for (int i = 0; i < t2len; i++)
       t2[i] = t1[i];
 
@@ -53,6 +53,8 @@ int main (int argc, char *argv[])
    for (const char *s = t2; s - t2 < t2len; s = fl_utf8fwd (s + 1, t2, t2 + t2len))
       printf ("%3d -> U+%04x\n", (int)(s - t2),
               decodeUtf8(s, t2len - (s - t2)));
+
+   delete[] t2;
 
    return 0;
 }


### PR DESCRIPTION
This PR changes the default flags in CFLAGS and CXXFLAGS to enable pedantic warnings and making Dillo strictly compliant with C90, C++11 and POSIX-2001.

Several non-portable code had to be modified to either use dlib functions or alternative portable functions.

Additionally, in the CI we enable `-Werror` so any pedantic warning makes the pipeline fail. It is important to allow other compilers to add pedantic warnings without breaking the build for users.

We can lower the C++11 to C++03 by getting rid of the macros, but it doesn't seem to be worth it for now.

Fixes #217 #218