### PR TITLE
Workaround for infinite layout loop

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,8 @@ dillo-3.2.0 [Not released yet]
  - Add line number anchors in HTML source view.
  - Make Dillo strictly C99, C++11 and POSIX-2001 compliant, without depending on
    GNU extensions.
+ - Perform an emergency stop of the layout engine loop after 1000 iterations to
+   prevent a hang.
    Patches: Rodrigo Arias Mallo
 +- Add primitive support for SVG using the nanosvg.h library.
    Patches: dogma, Rodrigo Arias Mallo

--- a/dw/layout.hh
+++ b/dw/layout.hh
@@ -246,7 +246,7 @@ private:
       ...Entered) defined here and in Widget. */
 
    int resizeIdleCounter, queueResizeCounter, sizeAllocateCounter,
-      sizeRequestCounter, getExtremesCounter;
+      sizeRequestCounter, getExtremesCounter, resizeCounter;
 
    void enterResizeIdle () { resizeIdleCounter++; }
    void leaveResizeIdle () { resizeIdleCounter--; }

--- a/src/cssparser.cc
+++ b/src/cssparser.cc
@@ -27,7 +27,8 @@
 
 using namespace dw::core::style;
 
-#define MSG_CSS(A, ...) MSG(A, __VA_ARGS__)
+//#define MSG_CSS(A, ...) _MSG(A, __VA_ARGS__)
+#define MSG_CSS(A, ...) do {} while(0)
 #define DEBUG_TOKEN_LEVEL   0
 #define DEBUG_PARSE_LEVEL   0
 #define DEBUG_CREATE_LEVEL  0

--- a/test/html/Makefile.am
+++ b/test/html/Makefile.am
@@ -14,6 +14,7 @@ TESTS = \
 	render/b-div.html \
 	render/div-100-percent-with-padding.html \
 	render/float-img-justify.html \
+	render/github-infinite-loop.html \
 	render/hackernews.html \
 	render/img-aspect-ratio.html \
 	render/main-style.html \
@@ -42,6 +43,7 @@ TESTS = \
 XFAIL_TESTS = \
 	render/div-100-percent-with-padding.html \
 	render/float-img-justify.html \
+	render/github-infinite-loop.html \
 	render/img-aspect-ratio.html \
 	render/margin-auto.html \
 	render/max-width-html.html \

--- a/test/html/Makefile.am
+++ b/test/html/Makefile.am
@@ -43,7 +43,6 @@ TESTS = \
 XFAIL_TESTS = \
 	render/div-100-percent-with-padding.html \
 	render/float-img-justify.html \
-	render/github-infinite-loop.html \
 	render/img-aspect-ratio.html \
 	render/margin-auto.html \
 	render/max-width-html.html \

--- a/test/html/render/github-infinite-loop.html
+++ b/test/html/render/github-infinite-loop.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>GitHub infinite layout loop</title>
+  </head>
+  <body>
+    <div style="display:inline-block">
+      <form style="float:left">
+        <input type="hidden"/>
+        <button type="submit" style="white-space:nowrap; float:left">Hello</button>
+      </form>
+    </div>
+  </body>
+</html>

--- a/test/html/render/github-infinite-loop.ref.html
+++ b/test/html/render/github-infinite-loop.ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>GitHub infinite layout loop</title>
+  </head>
+  <body>
+    <div style="display:inline-block">
+      <form style="float:left">
+        <input type="hidden"/>
+        <button type="submit" style="white-space:nowrap">Hello</button>
+      </form>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Workaround for #236, it stops the layout loop if we have reached 1000 iterations, so we don't enter an infinite loop and hoard the CPU forever. It also stops the layouting loop each 100 iterations to return the control to the FLTK event loop, so we keep the window responsive.

There is a bug in the layouting process involving floats and white-space wrapping that should be fixed. To debug it we will probably need the debug window merged first.