### PR TITLE
Stick to POSIX make rules

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -11,6 +11,6 @@ dillo.1: $(srcdir)/dillo.1.in Makefile
 
 # Use .in.html instead of .html.in so it is recognized as HTML.
 user_help.html: $(srcdir)/user_help.in.html Makefile
-	sed 's/__VERSION__/${VERSION}/g' $< > $@
+	sed 's/__VERSION__/${VERSION}/g' $(srcdir)/user_help.in.html > $@
 
 DISTCLEANFILES = dillo.1 user_help.html


### PR DESCRIPTION
Using $< in a non-suffix rule context is a GNUmake idiom

Reported-by: Alex <a1ex@dismail.de>
