### PR TITLE
Round CSS value after applying zoom level

### DIFF
--- a/src/styleengine.cc
+++ b/src/styleengine.cc
@@ -791,7 +791,7 @@ void StyleEngine::apply (int i, StyleAttrs *attrs, CssPropertyList *props,
 bool StyleEngine::computeValue (int *dest, CssLength value, Font *font) {
    switch (CSS_LENGTH_TYPE (value)) {
       case CSS_LENGTH_TYPE_PX:
-         *dest = (int) (CSS_LENGTH_VALUE (value) * zoom);
+         *dest = roundInt (CSS_LENGTH_VALUE (value) * zoom);
          return true;
       case CSS_LENGTH_TYPE_MM:
          *dest = roundInt (CSS_LENGTH_VALUE (value) * dpmm * zoom);


### PR DESCRIPTION
When a 1px value is used for the border, any zoom level that makes it
smaller makes the resulting size 0, so it disappears. Using round
instead leaves more room for zooming out before it disappears.

Fixes: https://github.com/dillo-browser/dillo/issues/240
