### PR TITLE
Fix heap use after free in TLS conn on errors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,7 @@ dillo-3.2.0 [Not released yet]
    GNU extensions.
  - Perform an emergency stop of the layout engine loop after 1000 iterations to
    prevent a hang.
+ - Fix use-after-free on errors in TLS connection.
    Patches: Rodrigo Arias Mallo
 +- Add primitive support for SVG using the nanosvg.h library.
    Patches: dogma, Rodrigo Arias Mallo

--- a/src/IO/tls_openssl.c
+++ b/src/IO/tls_openssl.c
@@ -1186,7 +1186,10 @@ static void Tls_connect(int fd, int connkey)
       if (a_Klist_get_data(conn_list, connkey)) {
          conn->connecting = FALSE;
          if (failed) {
+            conn->in_connect = FALSE;
             Tls_close_by_key(connkey);
+            /* conn is freed now */
+            conn = NULL;
          }
          a_IOwatch_remove_fd(fd, DIO_READ|DIO_WRITE);
          a_Http_connect_done(fd, failed ? FALSE : TRUE);
@@ -1195,7 +1198,8 @@ static void Tls_connect(int fd, int connkey)
       }
    }
 
-   conn->in_connect = FALSE;
+   if (conn)
+      conn->in_connect = FALSE;
 }
 
 static void Tls_connect_cb(int fd, void *vconnkey)


### PR DESCRIPTION
When a error causes the TLS connection to fail and stop, the conn struct is free on Tls_close_by_key(), so writing to conn->in_connect is not correct after that point. The solution is to only set the flag when the it is still valid.

Reported-by: Alex <a1ex@dismail.de>
Link: https://lists.mailman3.com/hyperkitty/list/dillo-dev@mailman3.com/thread/TY2JYCIPC7IQ32U6VC7ZOV3FVFFOE5K3/