### PR TITLE
Avoid expensive boundary search inside file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,8 @@ dillo-3.2.0 [Not released yet]
    Patches: Rodrigo Arias Mallo
 +- Add primitive support for SVG using the nanosvg.h library.
    Patches: dogma, Rodrigo Arias Mallo
++- Avoid expensive search for multipart/form-data boundaries.
+   Patches: Xavier Del Campo Romero, Rodrigo Arias Mallo
 
 dillo-3.1.1 [Jun 8, 2024]
 

--- a/src/dialog.cc
+++ b/src/dialog.cc
@@ -14,6 +14,7 @@
  */
 
 #include <math.h> // for rint()
+#include <string.h>
 
 #include <FL/fl_ask.H>
 #include <FL/Fl_Window.H>

--- a/src/form.cc
+++ b/src/form.cc
@@ -2,6 +2,7 @@
  * File: form.cc
  *
  * Copyright 2008 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1246,20 +1247,23 @@ Dstr *DilloHtmlForm::buildQueryData(DilloHtmlInput *active_submit)
    return DataStr;
 }
 
+/**
+ * Generate a random boundary.
+ *
+ * Using 70 random characters makes the probability that it collides
+ * with a 1 TiB random file less than 1e-117, so there is no need for
+ * checking for collisions. */
 static void generate_boundary(Dstr *boundary)
 {
+   /* Extracted from RFC 2046, section 5.1.1. */
+   static const char set[] = "abcdefghijklmnopqrstuvwxyz"
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      "0123456789";
+   static const size_t n = strlen(set);
+
    for (int i = 0; i < 70; i++) {
-      /* Extracted from RFC 2046, section 5.1.1. */
-      static const char set[] = "abcdefghijklmnopqrstuvwxyz"
-         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-         "0123456789";
-      char s[sizeof " "] = {0};
-
-      do {
-         *s = rand();
-      } while (!strspn(s, set));
-
-      dStr_append(boundary, s);
+      int c = (unsigned char) set[rand() % n];
+      dStr_append_c(boundary, c);
    }
 }
 

--- a/src/form.cc
+++ b/src/form.cc
@@ -1252,8 +1252,7 @@ static void generate_boundary(Dstr *boundary)
       /* Extracted from RFC 2046, section 5.1.1. */
       static const char set[] = "abcdefghijklmnopqrstuvwxyz"
          "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-         "0123456789"
-         "'()+_,-./:=? ";
+         "0123456789";
       char s[sizeof " "] = {0};
 
       do {


### PR DESCRIPTION
Prevents Dillo from checking if the boundary collides with the file by making the boundary have 70 random characters which have an extremely low probability of collision.