### PR TITLE
Add support for more CSS units

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,7 @@ dillo-3.2.0 [Not released yet]
  - Fix use-after-free on errors in TLS connection.
    Patches: Rodrigo Arias Mallo
 +- Add primitive support for SVG using the nanosvg.h library.
+ - Add support for ch, rem, vw, vh, vmin and vmax CSS units.
    Patches: dogma, Rodrigo Arias Mallo
 +- Avoid expensive search for multipart/form-data boundaries.
    Patches: Xavier Del Campo Romero, Rodrigo Arias Mallo

--- a/dw/fltkplatform.cc
+++ b/dw/fltkplatform.cc
@@ -122,6 +122,7 @@ FltkFont::FltkFont (core::style::FontAttrs *attrs)
    int xx, xy, xw, xh;
    fl_text_extents("x", xx, xy, xw, xh);
    xHeight = xh;
+   zeroWidth = (int) fl_width("0");
    descent = fl_descent();
    ascent = fl_height() - descent;
 }

--- a/dw/platform.hh
+++ b/dw/platform.hh
@@ -121,10 +121,11 @@ public:
     * is defined, which holds more platform dependent data.
     *
     * Also, this method must fill the attributes "font" (when needed),
-    * "ascent", "descent", "spaceSidth" and "xHeight". If "tryEverything"
-    * is true, several methods should be used to use another font, when
-    * the requested font is not available. Passing false is typically done,
-    * if the caller wants to test different variations.
+    * "ascent", "descent", "spaceSidth", "zeroWidth" and "xHeight". If
+    * "tryEverything" is true, several methods should be used to use
+    * another font, when the requested font is not available. Passing
+    * false is typically done, if the caller wants to test different
+    * variations.
     */
    virtual style::Font *createFont (style::FontAttrs *attrs,
                                     bool tryEverything) = 0;

--- a/dw/style.hh
+++ b/dw/style.hh
@@ -715,6 +715,7 @@ public:
    int ascent, descent;
    int spaceWidth;
    int xHeight;
+   int zeroWidth;
 
    static Font *create (Layout *layout, FontAttrs *attrs);
    static bool exists (Layout *layout, const char *name);

--- a/src/css.hh
+++ b/src/css.hh
@@ -78,6 +78,12 @@ typedef enum {
                                   millimeters. */
    CSS_LENGTH_TYPE_EM,
    CSS_LENGTH_TYPE_EX,
+   CSS_LENGTH_TYPE_CH,
+   CSS_LENGTH_TYPE_REM,
+   CSS_LENGTH_TYPE_VW,
+   CSS_LENGTH_TYPE_VH,
+   CSS_LENGTH_TYPE_VMIN,
+   CSS_LENGTH_TYPE_VMAX,
    CSS_LENGTH_TYPE_PERCENTAGE,
    CSS_LENGTH_TYPE_RELATIVE,   /**< This does not exist in CSS but
                                   is used in HTML */
@@ -104,6 +110,12 @@ inline CssLength CSS_CREATE_LENGTH (float v, CssLengthType t) {
    case CSS_LENGTH_TYPE_MM:
    case CSS_LENGTH_TYPE_EM:
    case CSS_LENGTH_TYPE_EX:
+   case CSS_LENGTH_TYPE_CH:
+   case CSS_LENGTH_TYPE_REM:
+   case CSS_LENGTH_TYPE_VW:
+   case CSS_LENGTH_TYPE_VH:
+   case CSS_LENGTH_TYPE_VMIN:
+   case CSS_LENGTH_TYPE_VMAX:
    case CSS_LENGTH_TYPE_PERCENTAGE:
    case CSS_LENGTH_TYPE_RELATIVE:
       l.f = v;
@@ -131,6 +143,12 @@ inline float CSS_LENGTH_VALUE (CssLength l) {
    case CSS_LENGTH_TYPE_MM:
    case CSS_LENGTH_TYPE_EM:
    case CSS_LENGTH_TYPE_EX:
+   case CSS_LENGTH_TYPE_CH:
+   case CSS_LENGTH_TYPE_REM:
+   case CSS_LENGTH_TYPE_VW:
+   case CSS_LENGTH_TYPE_VH:
+   case CSS_LENGTH_TYPE_VMIN:
+   case CSS_LENGTH_TYPE_VMAX:
    case CSS_LENGTH_TYPE_PERCENTAGE:
    case CSS_LENGTH_TYPE_RELATIVE:
       return l.f;

--- a/src/cssparser.cc
+++ b/src/cssparser.cc
@@ -3,6 +3,7 @@
  *
  * Copyright 2004 Sebastian Geerken <sgeerken@dillo.org>
  * Copyright 2008-2009 Johannes Hofmann <Johannes.Hofmann@gmx.de>
+ * Copyright 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -988,7 +989,7 @@ bool CssParser::parseValue(CssPropertyName prop,
             (type == CSS_TYPE_LENGTH_PERCENTAGE_NUMBER || fval == 0.0))
             ret = true;
 
-         val->intVal = CSS_CREATE_LENGTH(fval, lentype);
+         val->lenVal = CSS_CREATE_LENGTH(fval, lentype);
       }
       break;
 
@@ -1091,7 +1092,7 @@ bool CssParser::parseValue(CssPropertyName prop,
       // possibilities are tested in parallel.
 
       bool h[2], v[2];
-      int pos[2];
+      CssLength pos[2];
       h[0] = v[0] = h[1] = v[1] = false;
 
       // First: collect values in pos[0] and pos[1], and determine whether
@@ -1134,10 +1135,10 @@ bool CssParser::parseValue(CssPropertyName prop,
                // We can assume <length> or <percentage> here ...
                CssPropertyValue valTmp;
                if (parseValue(prop, CSS_TYPE_LENGTH_PERCENTAGE, &valTmp)) {
-                  pos[i] = valTmp.intVal;
+                  pos[i] = valTmp.lenVal;
                   ret = true;
                } else if (parseValue(prop, CSS_TYPE_SIGNED_LENGTH, &valTmp)) {
-                  pos[i] = valTmp.intVal;
+                  pos[i] = valTmp.lenVal;
                   ret = true;
                } else
                   // ... but something may still fail.

--- a/src/cssparser.cc
+++ b/src/cssparser.cc
@@ -968,6 +968,24 @@ bool CssParser::parseValue(CssPropertyName prop,
             } else if (dStrAsciiCasecmp(tval, "ex") == 0) {
                lentype = CSS_LENGTH_TYPE_EX;
                nextToken();
+            } else if (dStrAsciiCasecmp(tval, "ch") == 0) {
+               lentype = CSS_LENGTH_TYPE_CH;
+               nextToken();
+            } else if (dStrAsciiCasecmp(tval, "rem") == 0) {
+               lentype = CSS_LENGTH_TYPE_REM;
+               nextToken();
+            } else if (dStrAsciiCasecmp(tval, "vw") == 0) {
+               lentype = CSS_LENGTH_TYPE_VW;
+               nextToken();
+            } else if (dStrAsciiCasecmp(tval, "vh") == 0) {
+               lentype = CSS_LENGTH_TYPE_VH;
+               nextToken();
+            } else if (dStrAsciiCasecmp(tval, "vmin") == 0) {
+               lentype = CSS_LENGTH_TYPE_VMIN;
+               nextToken();
+            } else if (dStrAsciiCasecmp(tval, "vmax") == 0) {
+               lentype = CSS_LENGTH_TYPE_VMAX;
+               nextToken();
             } else {
                ret = false;
             }

--- a/src/html.cc
+++ b/src/html.cc
@@ -2205,32 +2205,32 @@ static bool Html_load_image(BrowserWindow *bw, DilloUrl *url,
 
 static void Html_tag_open_img(DilloHtml *html, const char *tag, int tagsize)
 {
-   int space, border;
+   int border;
    const char *attrbuf;
 
    a_Html_common_image_attrs(html, tag, tagsize);
 
    /* Spacing to the left and right */
    if ((attrbuf = a_Html_get_attr(html, tag, tagsize, "hspace"))) {
-      space = strtol(attrbuf, NULL, 10);
+      int space = strtol(attrbuf, NULL, 10);
       if (space > 0) {
-         space = CSS_CREATE_LENGTH(space, CSS_LENGTH_TYPE_PX);
+         CssLength len = CSS_CREATE_LENGTH(space, CSS_LENGTH_TYPE_PX);
          html->styleEngine->setNonCssHint (CSS_PROPERTY_MARGIN_LEFT,
-                                           CSS_TYPE_LENGTH_PERCENTAGE, space);
+                                           CSS_TYPE_LENGTH_PERCENTAGE, len);
          html->styleEngine->setNonCssHint (CSS_PROPERTY_MARGIN_RIGHT,
-                                           CSS_TYPE_LENGTH_PERCENTAGE, space);
+                                           CSS_TYPE_LENGTH_PERCENTAGE, len);
       }
    }
 
    /* Spacing at the top and bottom */
    if ((attrbuf = a_Html_get_attr(html, tag, tagsize, "vspace"))) {
-      space = strtol(attrbuf, NULL, 10);
+      int space = strtol(attrbuf, NULL, 10);
       if (space > 0) {
-         space = CSS_CREATE_LENGTH(space, CSS_LENGTH_TYPE_PX);
+         CssLength len = CSS_CREATE_LENGTH(space, CSS_LENGTH_TYPE_PX);
          html->styleEngine->setNonCssHint (CSS_PROPERTY_MARGIN_TOP,
-                                           CSS_TYPE_LENGTH_PERCENTAGE, space);
+                                           CSS_TYPE_LENGTH_PERCENTAGE, len);
          html->styleEngine->setNonCssHint (CSS_PROPERTY_MARGIN_BOTTOM,
-                                           CSS_TYPE_LENGTH_PERCENTAGE, space);
+                                           CSS_TYPE_LENGTH_PERCENTAGE, len);
       }
    }
 
@@ -2238,15 +2238,15 @@ static void Html_tag_open_img(DilloHtml *html, const char *tag, int tagsize)
    if ((attrbuf = a_Html_get_attr(html, tag, tagsize, "border"))) {
       border = strtol(attrbuf, NULL, 10);
       if (border >= 0) {
-         border = CSS_CREATE_LENGTH(border, CSS_LENGTH_TYPE_PX);
+         CssLength b = CSS_CREATE_LENGTH(border, CSS_LENGTH_TYPE_PX);
          html->styleEngine->setNonCssHint (CSS_PROPERTY_BORDER_TOP_WIDTH,
-                                           CSS_TYPE_LENGTH_PERCENTAGE, border);
+                                           CSS_TYPE_LENGTH_PERCENTAGE, b);
          html->styleEngine->setNonCssHint (CSS_PROPERTY_BORDER_BOTTOM_WIDTH,
-                                           CSS_TYPE_LENGTH_PERCENTAGE, border);
+                                           CSS_TYPE_LENGTH_PERCENTAGE, b);
          html->styleEngine->setNonCssHint (CSS_PROPERTY_BORDER_LEFT_WIDTH,
-                                           CSS_TYPE_LENGTH_PERCENTAGE, border);
+                                           CSS_TYPE_LENGTH_PERCENTAGE, b);
          html->styleEngine->setNonCssHint (CSS_PROPERTY_BORDER_RIGHT_WIDTH,
-                                           CSS_TYPE_LENGTH_PERCENTAGE, border);
+                                           CSS_TYPE_LENGTH_PERCENTAGE, b);
 
          html->styleEngine->setNonCssHint (CSS_PROPERTY_BORDER_TOP_STYLE,
                                            CSS_TYPE_ENUM, BORDER_SOLID);

--- a/src/html_common.hh
+++ b/src/html_common.hh
@@ -1,3 +1,16 @@
+/*
+ * File: html_common.hh
+ *
+ * Copyright (C) 2008-2016 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright (C) 2008-2014 Johannes Hofmann <Johannes.Hofmann@gmx.de>
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
 #ifndef __HTML_COMMON_HH__
 #define __HTML_COMMON_HH__
 
@@ -268,7 +281,7 @@ void a_Html_pop_tag(DilloHtml *html, int TagIdx);
 void a_Html_stash_init(DilloHtml *html);
 int32_t a_Html_color_parse(DilloHtml *html, const char *str,
                            int32_t default_color);
-dw::core::style::Length a_Html_parse_length (DilloHtml *html,
+CssLength a_Html_parse_length (DilloHtml *html,
                                              const char *attr);
 void a_Html_tag_set_align_attr(DilloHtml *html, const char *tag, int tagsize);
 bool a_Html_tag_set_valign_attr(DilloHtml *html,

--- a/src/styleengine.cc
+++ b/src/styleengine.cc
@@ -442,7 +442,7 @@ void StyleEngine::apply (int i, StyleAttrs *attrs, CssPropertyList *props,
                      assert(false); // invalid font-size enum
                }
             } else {
-               computeValue (&fontAttrs.size, p->value.intVal, parentFont,
+               computeValue (&fontAttrs.size, p->value.lenVal, parentFont,
                   parentFont->size);
             }
 
@@ -494,7 +494,7 @@ void StyleEngine::apply (int i, StyleAttrs *attrs, CssPropertyList *props,
                   fontAttrs.letterSpacing = 0;
                }
             } else {
-               computeValue (&fontAttrs.letterSpacing, p->value.intVal,
+               computeValue (&fontAttrs.letterSpacing, p->value.lenVal,
                   parentFont, parentFont->size);
             }
 
@@ -589,11 +589,11 @@ void StyleEngine::apply (int i, StyleAttrs *attrs, CssPropertyList *props,
             computeBorderWidth (&attrs->borderWidth.top, p, attrs->font);
             break;
          case CSS_PROPERTY_BORDER_SPACING:
-            computeValue (&attrs->hBorderSpacing, p->value.intVal,attrs->font);
-            computeValue (&attrs->vBorderSpacing, p->value.intVal,attrs->font);
+            computeValue (&attrs->hBorderSpacing, p->value.lenVal,attrs->font);
+            computeValue (&attrs->vBorderSpacing, p->value.lenVal,attrs->font);
             break;
          case CSS_PROPERTY_BOTTOM:
-            computeLength (&attrs->bottom, p->value.intVal, attrs->font);
+            computeLength (&attrs->bottom, p->value.lenVal, attrs->font);
             break;
          case CSS_PROPERTY_CLEAR:
             attrs->clear = (ClearType) p->value.intVal;
@@ -613,16 +613,16 @@ void StyleEngine::apply (int i, StyleAttrs *attrs, CssPropertyList *props,
             attrs->vloat = (FloatType) p->value.intVal;
             break;
          case CSS_PROPERTY_LEFT:
-            computeLength (&attrs->left, p->value.intVal, attrs->font);
+            computeLength (&attrs->left, p->value.lenVal, attrs->font);
             break;
          case CSS_PROPERTY_LINE_HEIGHT:
             if (p->type == CSS_TYPE_ENUM) { //only valid enum value is "normal"
                attrs->lineHeight = dw::core::style::LENGTH_AUTO;
             } else if (p->type == CSS_TYPE_LENGTH_PERCENTAGE_NUMBER) {
-               if (CSS_LENGTH_TYPE (p->value.intVal) == CSS_LENGTH_TYPE_NONE) {
+               if (CSS_LENGTH_TYPE (p->value.lenVal) == CSS_LENGTH_TYPE_NONE) {
                   attrs->lineHeight =
-                     createPerLength(CSS_LENGTH_VALUE(p->value.intVal));
-               } else if (computeValue (&lineHeight, p->value.intVal,
+                     createPerLength(CSS_LENGTH_VALUE(p->value.lenVal));
+               } else if (computeValue (&lineHeight, p->value.lenVal,
                                         attrs->font, attrs->font->size)) {
                   attrs->lineHeight = createAbsLength(lineHeight);
                }
@@ -635,22 +635,22 @@ void StyleEngine::apply (int i, StyleAttrs *attrs, CssPropertyList *props,
             attrs->listStyleType = (ListStyleType) p->value.intVal;
             break;
          case CSS_PROPERTY_MARGIN_BOTTOM:
-            computeValue (&attrs->margin.bottom, p->value.intVal, attrs->font);
+            computeValue (&attrs->margin.bottom, p->value.lenVal, attrs->font);
             if (attrs->margin.bottom < 0) // \todo fix negative margins in dw/*
                attrs->margin.bottom = 0;
             break;
          case CSS_PROPERTY_MARGIN_LEFT:
-            computeValue (&attrs->margin.left, p->value.intVal, attrs->font);
+            computeValue (&attrs->margin.left, p->value.lenVal, attrs->font);
             if (attrs->margin.left < 0) // \todo fix negative margins in dw/*
                attrs->margin.left = 0;
             break;
          case CSS_PROPERTY_MARGIN_RIGHT:
-            computeValue (&attrs->margin.right, p->value.intVal, attrs->font);
+            computeValue (&attrs->margin.right, p->value.lenVal, attrs->font);
             if (attrs->margin.right < 0) // \todo fix negative margins in dw/*
                attrs->margin.right = 0;
             break;
          case CSS_PROPERTY_MARGIN_TOP:
-            computeValue (&attrs->margin.top, p->value.intVal, attrs->font);
+            computeValue (&attrs->margin.top, p->value.lenVal, attrs->font);
             if (attrs->margin.top < 0) // \todo fix negative margins in dw/*
                attrs->margin.top = 0;
             break;
@@ -658,22 +658,22 @@ void StyleEngine::apply (int i, StyleAttrs *attrs, CssPropertyList *props,
             attrs->overflow = (Overflow) p->value.intVal;
             break;
          case CSS_PROPERTY_PADDING_TOP:
-            computeValue (&attrs->padding.top, p->value.intVal, attrs->font);
+            computeValue (&attrs->padding.top, p->value.lenVal, attrs->font);
             break;
          case CSS_PROPERTY_PADDING_BOTTOM:
-            computeValue (&attrs->padding.bottom, p->value.intVal,attrs->font);
+            computeValue (&attrs->padding.bottom, p->value.lenVal,attrs->font);
             break;
          case CSS_PROPERTY_PADDING_LEFT:
-            computeValue (&attrs->padding.left, p->value.intVal, attrs->font);
+            computeValue (&attrs->padding.left, p->value.lenVal, attrs->font);
             break;
          case CSS_PROPERTY_PADDING_RIGHT:
-            computeValue (&attrs->padding.right, p->value.intVal, attrs->font);
+            computeValue (&attrs->padding.right, p->value.lenVal, attrs->font);
             break;
          case CSS_PROPERTY_POSITION:
             attrs->position = (Position) p->value.intVal;
             break;
          case CSS_PROPERTY_RIGHT:
-            computeLength (&attrs->right, p->value.intVal, attrs->font);
+            computeLength (&attrs->right, p->value.lenVal, attrs->font);
             break;
          case CSS_PROPERTY_TEXT_ALIGN:
             attrs->textAlign = (TextAlignType) p->value.intVal;
@@ -682,13 +682,13 @@ void StyleEngine::apply (int i, StyleAttrs *attrs, CssPropertyList *props,
             attrs->textDecoration |= p->value.intVal;
             break;
          case CSS_PROPERTY_TEXT_INDENT:
-            computeLength (&attrs->textIndent, p->value.intVal, attrs->font);
+            computeLength (&attrs->textIndent, p->value.lenVal, attrs->font);
             break;
          case CSS_PROPERTY_TEXT_TRANSFORM:
             attrs->textTransform = (TextTransform) p->value.intVal;
             break;
          case CSS_PROPERTY_TOP:
-            computeLength (&attrs->top, p->value.intVal, attrs->font);
+            computeLength (&attrs->top, p->value.lenVal, attrs->font);
             break;
          case CSS_PROPERTY_VERTICAL_ALIGN:
             attrs->valign = (VAlignType) p->value.intVal;
@@ -697,10 +697,10 @@ void StyleEngine::apply (int i, StyleAttrs *attrs, CssPropertyList *props,
             attrs->whiteSpace = (WhiteSpace) p->value.intVal;
             break;
          case CSS_PROPERTY_WIDTH:
-            computeLength (&attrs->width, p->value.intVal, attrs->font);
+            computeLength (&attrs->width, p->value.lenVal, attrs->font);
             break;
          case CSS_PROPERTY_HEIGHT:
-            computeLength (&attrs->height, p->value.intVal, attrs->font);
+            computeLength (&attrs->height, p->value.lenVal, attrs->font);
             break;
          case CSS_PROPERTY_WORD_SPACING:
             if (p->type == CSS_TYPE_ENUM) {
@@ -708,7 +708,7 @@ void StyleEngine::apply (int i, StyleAttrs *attrs, CssPropertyList *props,
                   attrs->wordSpacing = 0;
                }
             } else {
-               computeValue(&attrs->wordSpacing, p->value.intVal, attrs->font);
+               computeValue(&attrs->wordSpacing, p->value.lenVal, attrs->font);
             }
 
             /* Limit to reasonable values to avoid overflows */
@@ -718,16 +718,16 @@ void StyleEngine::apply (int i, StyleAttrs *attrs, CssPropertyList *props,
                attrs->wordSpacing = -1000;
             break;
          case CSS_PROPERTY_MIN_WIDTH:
-            computeLength (&attrs->minWidth, p->value.intVal, attrs->font);
+            computeLength (&attrs->minWidth, p->value.lenVal, attrs->font);
             break;
          case CSS_PROPERTY_MAX_WIDTH:
-            computeLength (&attrs->maxWidth, p->value.intVal, attrs->font);
+            computeLength (&attrs->maxWidth, p->value.lenVal, attrs->font);
             break;
          case CSS_PROPERTY_MIN_HEIGHT:
-            computeLength (&attrs->minHeight, p->value.intVal, attrs->font);
+            computeLength (&attrs->minHeight, p->value.lenVal, attrs->font);
             break;
          case CSS_PROPERTY_MAX_HEIGHT:
-            computeLength (&attrs->maxHeight, p->value.intVal, attrs->font);
+            computeLength (&attrs->maxHeight, p->value.lenVal, attrs->font);
             break;
          case CSS_PROPERTY_Z_INDEX:
             if (p->type == CSS_LENGTH_TYPE_AUTO)
@@ -862,7 +862,7 @@ void StyleEngine::computeBorderWidth (int *dest, CssProperty *p,
             assert(false);
       }
    } else {
-      computeValue (dest, p->value.intVal, font);
+      computeValue (dest, p->value.lenVal, font);
    }
 }
 

--- a/src/styleengine.cc
+++ b/src/styleengine.cc
@@ -804,6 +804,32 @@ bool StyleEngine::computeValue (int *dest, CssLength value, Font *font) {
          /* Doesn't need zoom as it is already applied to font->xHeight */
          *dest = roundInt (CSS_LENGTH_VALUE(value) * font->xHeight);
          return true;
+      case CSS_LENGTH_TYPE_CH:
+         *dest = roundInt (CSS_LENGTH_VALUE(value) * font->zeroWidth);
+         return true;
+      case CSS_LENGTH_TYPE_REM:
+         if (stack->size() < 2) {
+            *dest = 0;
+         } else {
+            dw::core::style::Style *root_style = stack->getRef (1)->style;
+            if (root_style)
+               *dest = roundInt (CSS_LENGTH_VALUE(value) * root_style->font->size);
+            else
+               *dest = 0;
+         }
+         return true;
+      case CSS_LENGTH_TYPE_VW:
+         *dest = roundInt (CSS_LENGTH_VALUE(value) * layout->getWidthViewport() / 100);
+         return true;
+      case CSS_LENGTH_TYPE_VH:
+         *dest = roundInt (CSS_LENGTH_VALUE(value) * layout->getHeightViewport() / 100);
+         return true;
+      case CSS_LENGTH_TYPE_VMIN:
+         *dest = roundInt (CSS_LENGTH_VALUE(value) * MIN(layout->getWidthViewport(), layout->getHeightViewport()) / 100);
+         return true;
+      case CSS_LENGTH_TYPE_VMAX:
+         *dest = roundInt (CSS_LENGTH_VALUE(value) * MAX(layout->getWidthViewport(), layout->getHeightViewport()) / 100);
+         return true;
       case CSS_LENGTH_TYPE_NONE:
          // length values other than 0 without unit are only allowed
          // in special cases (line-height) and have to be handled

--- a/src/styleengine.hh
+++ b/src/styleengine.hh
@@ -108,6 +108,12 @@ class StyleEngine {
          v.strVal = dStrdup(value);
          setNonCssHint (name, type, v);
       }
+      inline void setNonCssHint(CssPropertyName name, CssValueType type,
+                                CssLength value) {
+         CssPropertyValue v;
+         v.lenVal = value;
+         setNonCssHint (name, type, v);
+      }
       void inheritNonCssHints ();
       void clearNonCssHints ();
       void restyle (BrowserWindow *bw);


### PR DESCRIPTION
Add support for more CSS units and changes the parser representation to a struct, so we don't need to eat more bits from the unit values.

Closes #48 and #174