### PR TITLE
Add support for left scrollbar

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,7 @@ dillo-3.2.0 [Not released yet]
    Patches: Rodrigo Arias Mallo
 +- Add primitive support for SVG using the nanosvg.h library.
  - Add support for ch, rem, vw, vh, vmin and vmax CSS units.
+ - Allow placing the scrollbar on the left side.
    Patches: dogma, Rodrigo Arias Mallo
 +- Avoid expensive search for multipart/form-data boundaries.
    Patches: Xavier Del Campo Romero, Rodrigo Arias Mallo

--- a/dillorc
+++ b/dillorc
@@ -46,6 +46,9 @@
 # height of the visible page area.
 #scroll_step=100
 
+# Place the vertical scrollbar on the left side (default right).
+#scrollbar_on_left=NO
+
 #-------------------------------------------------------------------------
 #                           RENDERING SECTION
 #-------------------------------------------------------------------------

--- a/doc/user_help.in.html
+++ b/doc/user_help.in.html
@@ -208,7 +208,10 @@ doesn't require a network connection.
 
 <p>You can control the <b>size of a <em>step</em></b> by setting the
 <code>scroll_step</code> option in the <a href="#dillorc">dillorc</a>
-configuration file. By default it will scroll 100 pixels per step.</p>
+configuration file. By default it will scroll 100 pixels per step. The vertical
+scrollbar can be positioned on the left side setting the
+<code>scrollbar_on_left</code> option to <code>YES</code>, by default it is on
+the right side.</p>
 
 <h3 id="find-text">Find text</h3>
 <p>

--- a/dw/fltkflatview.cc
+++ b/dw/fltkflatview.cc
@@ -70,6 +70,11 @@ int FltkFlatView::getVScrollbarThickness ()
    return 0;
 }
 
+int FltkFlatView::getScrollbarOnLeft ()
+{
+   return 0;
+}
+
 void FltkFlatView::scrollTo (int x, int y)
 {
 }

--- a/dw/fltkflatview.hh
+++ b/dw/fltkflatview.hh
@@ -25,6 +25,7 @@ public:
    bool usesViewport ();
    int getHScrollbarThickness ();
    int getVScrollbarThickness ();
+   int getScrollbarOnLeft ();
    void scrollTo (int x, int y);
    void setViewportSize (int width, int height,
                          int hScrollbarThickness, int vScrollbarThickness);

--- a/dw/fltkpreview.cc
+++ b/dw/fltkpreview.cc
@@ -95,6 +95,11 @@ int FltkPreview::getVScrollbarThickness ()
    return 0;
 }
 
+int FltkPreview::getScrollbarOnLeft ()
+{
+   return 0;
+}
+
 void FltkPreview::scrollTo (int x, int y)
 {
    scrollX = x;

--- a/dw/fltkpreview.hh
+++ b/dw/fltkpreview.hh
@@ -33,6 +33,7 @@ public:
    bool usesViewport ();
    int getHScrollbarThickness ();
    int getVScrollbarThickness ();
+   int getScrollbarOnLeft ();
    void scrollTo (int x, int y);
    void scroll (dw::core::ScrollCommand cmd);
    void setViewportSize (int width, int height,

--- a/dw/fltkviewport.hh
+++ b/dw/fltkviewport.hh
@@ -21,6 +21,7 @@ private:
 
    int scrollX, scrollY;
    int scrollDX, scrollDY;
+   int scrollbarOnLeft;
    int hasDragScroll, dragScrolling, dragX, dragY;
    int horScrolling, verScrolling;
 
@@ -64,6 +65,7 @@ public:
    bool usesViewport ();
    int getHScrollbarThickness ();
    int getVScrollbarThickness ();
+   int getScrollbarOnLeft () {return scrollbarOnLeft; };
    void scroll(int dx, int dy);
    void scroll(dw::core::ScrollCommand cmd);
    void scrollTo (int x, int y);
@@ -75,6 +77,7 @@ public:
                               GadgetOrientation gadgetOrientation);
    void setDragScroll (bool enable) { hasDragScroll = enable ? 1 : 0; }
    void addGadget (Fl_Widget *gadget);
+   void setScrollbarOnLeft (bool enable);
 };
 
 } // namespace fltk

--- a/dw/layout.cc
+++ b/dw/layout.cc
@@ -943,6 +943,8 @@ void Layout::resizeIdle ()
          assert (topLevel->needsAllocate ());
 
          allocation.x = allocation.y = 0;
+         if (usesViewport && view->getScrollbarOnLeft())
+            allocation.x += currVScrollbarThickness();
          allocation.width = requisition.width;
          allocation.ascent = requisition.ascent;
          allocation.descent = requisition.descent;

--- a/dw/view.hh
+++ b/dw/view.hh
@@ -72,6 +72,8 @@ public:
     */
    virtual int getVScrollbarThickness () = 0;
 
+   virtual int getScrollbarOnLeft () = 0;
+
    /**
     * \brief Scroll the vieport to the given position.
     *

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -91,6 +91,7 @@ void a_Prefs_init(void)
    prefs.search_urls = dList_new(16);
    dList_append(prefs.search_urls, dStrdup(PREFS_SEARCH_URL));
    prefs.search_url_idx = 0;
+   prefs.scrollbar_on_left = FALSE;
    prefs.show_back = TRUE;
    prefs.show_bookmarks = TRUE;
    prefs.show_clear_url = TRUE;

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -77,6 +77,7 @@ typedef struct {
    int32_t font_max_size;
    int32_t font_min_size;
    int32_t scroll_step;
+   bool_t scrollbar_on_left;
    bool_t show_back;
    bool_t show_forw;
    bool_t show_home;

--- a/src/prefsparser.cc
+++ b/src/prefsparser.cc
@@ -200,6 +200,7 @@ void PrefsParser::parse(FILE *fp)
       { "parse_embedded_css", &prefs.parse_embedded_css, PREFS_BOOL, 0 },
       { "save_dir", &prefs.save_dir, PREFS_STRING, 0 },
       { "scroll_step", &prefs.scroll_step, PREFS_INT32, 0 },
+      { "scrollbar_on_left", &prefs.scrollbar_on_left, PREFS_BOOL, 0 },
       { "search_url", &prefs.search_urls, PREFS_STRINGS, 0 },
       { "show_back", &prefs.show_back, PREFS_BOOL, 0 },
       { "show_bookmarks", &prefs.show_bookmarks, PREFS_BOOL, 0 },

--- a/src/uicmd.cc
+++ b/src/uicmd.cc
@@ -628,6 +628,7 @@ static BrowserWindow *UIcmd_tab_new(CustTabs *tabs, UI *old_ui, int focus)
    viewport->box(FL_NO_BOX);
    viewport->setBufferedDrawing (prefs.buffered_drawing ? true : false);
    viewport->setDragScroll (prefs.middle_click_drags_page ? true : false);
+   viewport->setScrollbarOnLeft (prefs.scrollbar_on_left ? true : false);
    layout->attachView (viewport);
    new_ui->set_render_layout(viewport);
    viewport->setScrollStep(prefs.scroll_step);


### PR DESCRIPTION
Implements support for placing the vertical scrollbar on the left side by setting `scrollbar_on_left=YES` on dillorc. By default, continues to be on the right side.

![scrollbar-left2](https://github.com/user-attachments/assets/fb6e645a-45a7-4ebf-8336-a89a39f1b29a)


See: https://www.toomanyatoms.com/software/mobilized_dillo.html
Authored-By: dogma