### PR TITLE
Control the page overlap independently

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,7 @@ dillo-3.2.0 [Not released yet]
    prevent a hang.
  - Fix use-after-free on errors in TLS connection.
  - Add scrollbar_page_mode option to easily scroll full pages with the mouse.
+ - Control the page overlap with the scroll_page_overlap option.
    Patches: Rodrigo Arias Mallo
 +- Add primitive support for SVG using the nanosvg.h library.
  - Add support for ch, rem, vw, vh, vmin and vmax CSS units.

--- a/dillorc
+++ b/dillorc
@@ -42,9 +42,12 @@
 
 # Set the increment in pixels that the page is moved up/down with each input
 # from the mouse wheel, keyboard arrow keys, or scrollbar arrow buttons.
-# Page movement with the Page Up/Down keys is one scroll_step less than the
-# height of the visible page area.
 #scroll_step=100
+
+# Controls the overlap in pixels when scrolling to the next or previous page.
+# It is used to repeat the last line(s) to avoid losing the reading flow. It
+# controls the overlap in both the vertical and horizontal directions.
+#scroll_page_overlap=50
 
 # Place the vertical scrollbar on the left side (default right).
 #scrollbar_on_left=NO

--- a/dw/fltkviewport.cc
+++ b/dw/fltkviewport.cc
@@ -73,6 +73,7 @@ FltkViewport::FltkViewport (int X, int Y, int W, int H, const char *label):
    scrollX = scrollY = scrollDX = scrollDY = 0;
    horScrolling = verScrolling = dragScrolling = 0;
    scrollbarPageMode = false;
+   pageOverlap = 50;
 
    gadgetOrientation[0] = GADGET_HORIZONTAL;
    gadgetOrientation[1] = GADGET_HORIZONTAL;
@@ -434,6 +435,11 @@ void FltkViewport::setScrollStep(int step)
    hscrollbar->linesize(step);
 }
 
+void FltkViewport::setPageOverlap(int overlap)
+{
+   pageOverlap = overlap;
+}
+
 void FltkViewport::setScrollbarPageMode(bool enable)
 {
    scrollbarPageMode = enable;
@@ -493,13 +499,13 @@ void FltkViewport::scroll (int dx, int dy)
 void FltkViewport::scroll (core::ScrollCommand cmd)
 {
    if (cmd == core::SCREEN_UP_CMD) {
-      scroll (0, -h () + vscrollbar->linesize ());
+      scroll (0, -h () + pageOverlap);
    } else if (cmd == core::SCREEN_DOWN_CMD) {
-      scroll (0, h () - vscrollbar->linesize ());
+      scroll (0, h () - pageOverlap);
    } else if (cmd == core::SCREEN_LEFT_CMD) {
-      scroll (-w() + hscrollbar->linesize (), 0);
+      scroll (-w() + pageOverlap, 0);
    } else if (cmd == core::SCREEN_RIGHT_CMD) {
-      scroll (w() - hscrollbar->linesize (), 0);
+      scroll (w() - pageOverlap, 0);
    } else if (cmd == core::LINE_UP_CMD) {
       scroll (0, -vscrollbar->linesize ());
    } else if (cmd == core::LINE_DOWN_CMD) {

--- a/dw/fltkviewport.hh
+++ b/dw/fltkviewport.hh
@@ -45,6 +45,7 @@ private:
    int hasDragScroll, dragScrolling, dragX, dragY;
    int horScrolling, verScrolling;
    bool scrollbarPageMode;
+   int pageOverlap;
 
    Fl_Scrollbar *vscrollbar, *hscrollbar;
 
@@ -100,6 +101,7 @@ public:
    void addGadget (Fl_Widget *gadget);
    void setScrollbarOnLeft (bool enable);
    void setScrollbarPageMode(bool enable);
+   void setPageOverlap(int overlap);
 };
 
 } // namespace fltk

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -88,6 +88,7 @@ void a_Prefs_init(void)
    prefs.parse_embedded_css=TRUE;
    prefs.save_dir = dStrdup(PREFS_SAVE_DIR);
    prefs.scroll_step = 100;
+   prefs.scroll_page_overlap = 50;
    prefs.search_urls = dList_new(16);
    dList_append(prefs.search_urls, dStrdup(PREFS_SEARCH_URL));
    prefs.search_url_idx = 0;

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -77,6 +77,7 @@ typedef struct {
    int32_t font_max_size;
    int32_t font_min_size;
    int32_t scroll_step;
+   int32_t scroll_page_overlap;
    bool_t scrollbar_on_left;
    bool_t scrollbar_page_mode;
    bool_t show_back;

--- a/src/prefsparser.cc
+++ b/src/prefsparser.cc
@@ -200,6 +200,7 @@ void PrefsParser::parse(FILE *fp)
       { "parse_embedded_css", &prefs.parse_embedded_css, PREFS_BOOL, 0 },
       { "save_dir", &prefs.save_dir, PREFS_STRING, 0 },
       { "scroll_step", &prefs.scroll_step, PREFS_INT32, 0 },
+      { "scroll_page_overlap", &prefs.scroll_page_overlap, PREFS_INT32, 0 },
       { "scrollbar_on_left", &prefs.scrollbar_on_left, PREFS_BOOL, 0 },
       { "scrollbar_page_mode", &prefs.scrollbar_page_mode, PREFS_BOOL, 0 },
       { "search_url", &prefs.search_urls, PREFS_STRINGS, 0 },

--- a/src/uicmd.cc
+++ b/src/uicmd.cc
@@ -633,6 +633,7 @@ static BrowserWindow *UIcmd_tab_new(CustTabs *tabs, UI *old_ui, int focus)
    layout->attachView (viewport);
    new_ui->set_render_layout(viewport);
    viewport->setScrollStep(prefs.scroll_step);
+   viewport->setPageOverlap(prefs.scroll_page_overlap);
 
    // Now, create a new browser window structure
    BrowserWindow *new_bw = a_Bw_new();


### PR DESCRIPTION
Introduces the new option scroll_page_overlap to control the amount of pixels of overlap when scrolling to the next or previous page. Previously this value was taken from scroll_step, but now they are controlled independently.

Fixes: https://github.com/dillo-browser/dillo/issues/276