### PR TITLE
Only use full URL for HTTP proxies

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,7 @@ dillo-3.2.0 [Not released yet]
  - Add scrollbar_page_mode option to easily scroll full pages with the mouse.
  - Control the page overlap with the scroll_page_overlap option.
  - Set focus_new_tab=NO and show_quit_dialog=NO by default.
+ - Fix GET requests over HTTPS via a proxy.
    Patches: Rodrigo Arias Mallo
 +- Add primitive support for SVG using the nanosvg.h library.
  - Add support for ch, rem, vw, vh, vmin and vmax CSS units.


### PR DESCRIPTION
When performing a HTTPS request over a HTTP proxy, a direct connection is made to the remote server, so the GET line will be received as is. Therefore we shouldn't send the full URL but just the path.

Fixes: https://github.com/dillo-browser/dillo/issues/279