### PR TITLE
Don't add border on images with a link

### DIFF
--- a/src/styleengine.cc
+++ b/src/styleengine.cc
@@ -1031,7 +1031,6 @@ void StyleEngine::init () {
       " h1, h2, h3, h4, h5, h6, header, main, nav, ol, p, pre, section, ul"
       " {display: block}"
       "i, em, cite, address, var {font-style: italic}"
-      ":link img, :visited img {border: 1px solid}"
       "frameset, ul, ol, dir {margin-left: 40px}"
       /* WORKAROUND: It should be margin: 1em 0
        * but as we don't collapse these margins yet, it


### PR DESCRIPTION
Some images have the same background color as the page so they don't have a visible border. Always adding a border on images with a link breaks this property. Links continue to be discoverable by hovering with the mouse.

Fixes: https://github.com/dillo-browser/dillo/issues/270