### PR TITLE
Reload the current page on SIGUSR1 signal

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,7 @@ dillo-3.2.0 [Not released yet]
  - Set focus_new_tab=NO and show_quit_dialog=NO by default.
  - Fix GET requests over HTTPS via a proxy.
  - Improve image resize logic to always try to preserve the aspect ratio.
+ - Reload current page on SIGUSR1 signal
    Patches: Rodrigo Arias Mallo
 +- Add primitive support for SVG using the nanosvg.h library.
  - Add support for ch, rem, vw, vh, vmin and vmax CSS units.

--- a/src/uicmd.hh
+++ b/src/uicmd.hh
@@ -37,6 +37,7 @@ void a_UIcmd_zoom_in(void *vbw);
 void a_UIcmd_zoom_out(void *vbw);
 void a_UIcmd_zoom_reset(void *vbw);
 void a_UIcmd_reload(void *vbw);
+void a_UIcmd_reload_all_active();
 void a_UIcmd_repush(void *vbw);
 void a_UIcmd_redirection0(void *vbw, const DilloUrl *url);
 void a_UIcmd_save(void *vbw);


### PR DESCRIPTION
Fixes: https://github.com/dillo-browser/dillo/issues/255

Known limitations: External CSS and images are not fetched again, refetching them again causes issues.