### PR TITLE
Always include the path "/" in HTTP requests

### DIFF
--- a/src/IO/http.c
+++ b/src/IO/http.c
@@ -407,11 +407,10 @@ static Dstr *Http_make_query_str(DilloWeb *web, bool_t use_proxy, bool_t use_tls
          dStr_sprintf(proxy_auth, "Proxy-Authorization: Basic %s\r\n",
                       HTTP_Proxy_Auth_base64);
    } else {
-      dStr_sprintfa(request_uri, "%s%s%s%s",
-                    URL_PATH(url),
+      dStr_sprintfa(request_uri, "%s%s%s",
+                    URL_PATH_(url) ? URL_PATH(url) : "/",
                     URL_QUERY_(url) ? "?" : "",
-                    URL_QUERY(url),
-                    (URL_PATH_(url) || URL_QUERY_(url)) ? "" : "/");
+                    URL_QUERY(url));
    }
 
    cookies = a_Cookies_get_query(url, web->requester);


### PR DESCRIPTION
Following https://datatracker.ietf.org/doc/html/rfc7230#section-5.3.1, the path must not be empty, even if we have a query:

> If the target URI's path component is empty, the client MUST send "/"
> as the path within the origin-form of request-target.

Notice URIs can have empty paths, this is a restriction of HTTP only.

Fixes: https://github.com/dillo-browser/dillo/issues/302