### PR TITLE
Prevent using FLTK 1.4 for now

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -218,6 +218,8 @@ case $fltk_version in
          LIBFLTK_CXXFLAGS=`$FLTK_CONFIG --cxxflags`
          LIBFLTK_CFLAGS=`$FLTK_CONFIG --cflags`
          LIBFLTK_LIBS=`$FLTK_CONFIG --ldflags`;;
+  1.4.*) AC_MSG_RESULT(no)
+         AC_MSG_ERROR([FLTK $fltk_version not supported yet; use FLTK 1.3]);;
   ?*)    AC_MSG_RESULT(no)
          AC_MSG_ERROR(FLTK 1.3 required; version found: $fltk_version);;
   *)     AC_MSG_RESULT(no)


### PR DESCRIPTION
There are several problems that need to be resolved before we can switch to FLTK 1.4. The support is intentionally disabled until it is ready.

See: https://github.com/dillo-browser/dillo/issues/246