### PR TITLE
Print version of libraries and features

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -27,6 +27,7 @@ dillo-3.2.0 [Not released yet]
  - Fix GET requests over HTTPS via a proxy.
  - Improve image resize logic to always try to preserve the aspect ratio.
  - Reload current page on SIGUSR1 signal
+ - Print library versions and enabled features with dillo -v.
    Patches: Rodrigo Arias Mallo
 +- Add primitive support for SVG using the nanosvg.h library.
  - Add support for ch, rem, vw, vh, vmin and vmax CSS units.

--- a/src/IO/tls.c
+++ b/src/IO/tls.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2011 Benjamin Johnson <obeythepenguin@users.sourceforge.net>
  * (for the https code offered from dplus browser that formed the basis...)
  * Copyright 2016 corvid
- * Copyright (C) 2023 Rodrigo Arias Mallo <rodarima@gmail.com>
+ * Copyright (C) 2023-2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,6 +24,22 @@
 #include "tls.h"
 #include "tls_openssl.h"
 #include "tls_mbedtls.h"
+
+/**
+ * Get the version of the TLS library.
+ */
+const char *a_Tls_version(char *buf, int n)
+{
+#if ! defined(ENABLE_TLS)
+   return NULL;
+#elif defined(HAVE_OPENSSL)
+   return a_Tls_openssl_version(buf, n);
+#elif defined(HAVE_MBEDTLS)
+   return a_Tls_mbedtls_version(buf, n);
+#else
+# error "no TLS library found but ENABLE_TLS set"
+#endif
+}
 
 /**
  * Initialize TLS library.

--- a/src/IO/tls.h
+++ b/src/IO/tls.h
@@ -4,7 +4,7 @@
  * Copyright (C) 2011 Benjamin Johnson <obeythepenguin@users.sourceforge.net>
  * (for the https code offered from dplus browser that formed the basis...)
  * Copyright 2016 corvid
- * Copyright (C) 2023 Rodrigo Arias Mallo <rodarima@gmail.com>
+ * Copyright (C) 2023-2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,6 +31,7 @@ extern "C" {
 #define TLS_CONNECT_NOT_YET 0
 #define TLS_CONNECT_READY 1
 
+const char *a_Tls_version(char *buf, int n);
 void a_Tls_init(void);
 int a_Tls_certificate_is_clean(const DilloUrl *url);
 int a_Tls_connect_ready(const DilloUrl *url);

--- a/src/IO/tls_mbedtls.c
+++ b/src/IO/tls_mbedtls.c
@@ -355,6 +355,17 @@ static void Tls_remove_psk_ciphersuites()
    mbedtls_ssl_conf_ciphersuites(&ssl_conf, our_ciphers);
 }
 
+const char *a_Tls_mbedtls_version(char *buf, int n)
+{
+   char ver[128]; /* Only 9 characters needed */
+   mbedtls_version_get_string(ver);
+
+   int k = snprintf(buf, n, "mbedTLS/%s", ver);
+   if (k >= n)
+      return "mbedTLS/?";
+   return buf;
+}
+
 /*
  * Initialize the mbed TLS library.
  */

--- a/src/IO/tls_mbedtls.h
+++ b/src/IO/tls_mbedtls.h
@@ -4,7 +4,7 @@
  * Copyright (C) 2011 Benjamin Johnson <obeythepenguin@users.sourceforge.net>
  * (for the https code offered from dplus browser that formed the basis...)
  * Copyright 2016 corvid
- * Copyright (C) 2023 Rodrigo Arias Mallo <rodarima@gmail.com>
+ * Copyright (C) 2023-2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@ extern "C" {
 
 #include "../url.h"
 
+const char *a_Tls_mbedtls_version(char *buf, int n);
 void a_Tls_mbedtls_init(void);
 int a_Tls_mbedtls_certificate_is_clean(const DilloUrl *url);
 int a_Tls_mbedtls_connect_ready(const DilloUrl *url);

--- a/src/IO/tls_openssl.c
+++ b/src/IO/tls_openssl.c
@@ -246,6 +246,27 @@ static void Tls_load_certificates(void)
       ;
 }
 
+const char *a_Tls_openssl_version(char *buf, int n)
+{
+   /* Ugly hack to replace "OpenSSL 3.4.0 22 Oct 2024" with
+    * "OpenSSL/3.4.0". It also works for LibreSSL. */
+   const char *ver = OpenSSL_version(OPENSSL_VERSION);
+   if (snprintf(buf, n, "%s", ver) >= n)
+      return "OpenSSL/?";
+
+   char *ossl = buf;
+   char *sp1 = strchr(ossl, ' ');
+   if (sp1) {
+      *sp1 = '/';
+      char *sp2 = strchr(ossl, ' ');
+      if (sp2) {
+         *sp2 = '\0';
+      }
+   }
+
+   return buf;
+}
+
 /*
  * Initialize the OpenSSL library.
  */

--- a/src/IO/tls_openssl.h
+++ b/src/IO/tls_openssl.h
@@ -8,7 +8,7 @@
  * (for the certificate hostname checking from wget)
  * Copyright (C) 2011 Benjamin Johnson <obeythepenguin@users.sourceforge.net>
  * (for the https code offered from dplus browser that formed the basis...)
- * Copyright (C) 2023 Rodrigo Arias Mallo <rodarima@gmail.com>
+ * Copyright (C) 2023-2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,6 +31,7 @@ extern "C" {
 
 #include "../url.h"
 
+const char *a_Tls_openssl_version(char *buf, int n);
 void a_Tls_openssl_init(void);
 int a_Tls_openssl_certificate_is_clean(const DilloUrl *url);
 int a_Tls_openssl_connect_ready(const DilloUrl *url);

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,6 +25,8 @@ dillo_LDADD = \
 
 dillo_SOURCES = \
 	dillo.cc \
+	version.cc \
+	version.hh \
 	paths.cc \
 	paths.hh \
 	tipwin.cc \

--- a/src/dillo.cc
+++ b/src/dillo.cc
@@ -47,6 +47,7 @@
 #include "bw.h"
 #include "misc.h"
 #include "history.h"
+#include "version.hh"
 
 #include "dns.h"
 #include "web.hh"
@@ -441,7 +442,7 @@ int main(int argc, char **argv)
          }
          break;
       case DILLO_CLI_VERSION:
-         puts("Dillo version " VERSION);
+         a_Version_print_info();
          return 0;
       case DILLO_CLI_HELP:
          printHelp(argv[0], Options);

--- a/src/djpeg.h
+++ b/src/djpeg.h
@@ -11,6 +11,7 @@ extern "C" {
 
 void *a_Jpeg_new(DilloImage *Image, DilloUrl *url, int version);
 void a_Jpeg_callback(int Op, void *data);
+const char *a_Jpeg_version(void);
 
 
 #ifdef __cplusplus

--- a/src/dpng.h
+++ b/src/dpng.h
@@ -7,10 +7,12 @@ extern "C" {
 
 #include "url.h"
 #include "image.hh"
+#include "cache.h"
 
 
 void *a_Png_new(DilloImage *Image, DilloUrl *url, int version);
 void a_Png_callback(int Op, CacheClient_t *Client);
+const char *a_Png_version(void);
 
 
 #ifdef __cplusplus

--- a/src/jpeg.c
+++ b/src/jpeg.c
@@ -2,6 +2,7 @@
  * File: jpeg.c
  *
  * Copyright (C) 2000-2007 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -232,6 +233,21 @@ void a_Jpeg_callback(int Op, void *data)
    }
 }
 
+const char *a_Jpeg_version(void)
+{
+#define QUOTE(x) #x
+#define STR(x) QUOTE(x)
+
+#if defined(LIBJPEG_TURBO_VERSION)
+   return STR(LIBJPEG_TURBO_VERSION);
+#else
+   return STR(JPEG_LIB_VERSION);
+#endif
+
+#undef STR
+#undef QUOTE
+}
+
 /**
  * Receive and process new chunks of JPEG image data
  */
@@ -405,5 +421,6 @@ static void Jpeg_write(DilloJpeg *jpeg, void *Buf, uint_t BufSize)
 
 void *a_Jpeg_new() { return 0; }
 void a_Jpeg_callback() { return; }
+const char *a_Jpeg_version(void) { return NULL; }
 
 #endif /* ENABLE_JPEG */

--- a/src/png.c
+++ b/src/png.c
@@ -2,6 +2,7 @@
  * Copyright Geoff Lane nov 1999 zzassgl@twirl.mcc.ac.uk
  * Copyright Luca Rota, Jorge Arellano Cid, Eric Gaudet 2000
  * Copyright Jorge Arellano Cid 2009
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
  */
 
 /**
@@ -436,6 +437,11 @@ void a_Png_callback(int Op, void *data)
    }
 }
 
+const char *a_Png_version(void)
+{
+   return png_get_libpng_ver(NULL);
+}
+
 /**
  * Create the image state data that must be kept between calls
  */
@@ -465,5 +471,6 @@ void *a_Png_new(DilloImage *Image, DilloUrl *url, int version)
 
 void *a_Png_new() { return 0; }
 void a_Png_callback() { return; }
+const char *a_Png_version(void) { return NULL; }
 
 #endif /* ENABLE_PNG */

--- a/src/version.cc
+++ b/src/version.cc
@@ -1,0 +1,106 @@
+/*
+ * Dillo web browser
+ *
+ * Copyright 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "djpeg.h"
+#include "dpng.h"
+#include "IO/tls.h"
+
+#include <FL/Fl.H>
+#include <zlib.h>
+
+#include <stdio.h>
+
+static void print_libs()
+{
+   char buf[256];
+
+   printf("Libraries:");
+
+   /* FLTK only offers a single number */
+   {
+      int fltkver = Fl::api_version();
+      int fltk_maj = fltkver / 10000;
+      int fltk_min = (fltkver / 100) % 100;
+      int fltk_pat = fltkver % 100;
+      printf(" fltk/%d.%d.%d", fltk_maj, fltk_min, fltk_pat);
+   }
+
+   printf(" zlib/%s", zlibVersion());
+
+#ifdef ENABLE_JPEG
+   printf(" jpeg/%s", a_Jpeg_version());
+#endif
+
+#ifdef ENABLE_PNG
+   printf(" png/%s", a_Png_version());
+#endif
+
+#ifdef ENABLE_TLS
+   /* TLS prints the name/version format, as it determines which SSL
+    * library is in use */
+   printf(" %s", a_Tls_version(buf, 256));
+#endif
+
+   printf("\n");
+}
+
+static void print_features()
+{
+   printf("Features:"
+#ifdef ENABLE_GIF
+         " +GIF"
+#else
+         " -GIF"
+#endif
+#ifdef ENABLE_JPEG
+         " +JPEG"
+#else
+         " -JPEG"
+#endif
+#ifdef ENABLE_PNG
+         " +PNG"
+#else
+         " -PNG"
+#endif
+#ifdef ENABLE_SVG
+         " +SVG"
+#else
+         " -SVG"
+#endif
+#if !( defined(DISABLE_XEMBED) || defined(WIN32) || defined(__APPLE__) )
+         " +XEMBED"
+#else
+         " -XEMBED"
+#endif
+#ifdef ENABLE_TLS
+         " +TLS"
+#else
+         " -TLS"
+#endif
+         "\n");
+}
+
+void a_Version_print_info(void)
+{
+   printf("Dillo version " VERSION "\n");
+   print_libs();
+   print_features();
+}

--- a/src/version.hh
+++ b/src/version.hh
@@ -1,0 +1,25 @@
+/*
+ * Dillo web browser
+ *
+ * Copyright 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef VERSION_HH
+#define VERSION_HH
+
+void a_Version_print_info();
+
+#endif /* VERSION_HH */


### PR DESCRIPTION
    When reporting the version of Dillo with -v, print also the version of
    the libraries it is currently using, as well as the features that were
    enabled at build time. Notice the versions are reported by reading them
    at runtime, so we can detect the version loaded at run time, regardless
    of which version was used at link time.

    All features are always printed, but prefixes with + if enabled or - if
    disabled. This allows checking if the feature was disabled at configure
    time or if it is missing in that version of Dillo.