### PR TITLE
Pin FLTK to 1.3 in homebrew

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: master
 
 jobs:
   ubuntu-latest-html-tests:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,17 +180,21 @@ jobs:
       with:
         fetch-depth: 1
     - name: Install dependencies
-      run: brew install autoconf automake fltk
+      run: brew install autoconf automake fltk@1.3
     - name: autogen
       run: ./autogen.sh
     - name: configure
-      run: ./configure --disable-mbedtls
+      run: |
+        export PATH="/usr/local/opt/fltk@1.3/bin:$PATH"
+        ./configure --disable-mbedtls
     - name: make
       run: make
     - name: make check
       run: make check
     - name: make distcheck
-      run: make distcheck
+      run: |
+        export PATH="/usr/local/opt/fltk@1.3/bin:$PATH"
+        make distcheck
   macOS-13-openssl-3:
     needs: ubuntu-latest-html-tests
     runs-on: macos-13
@@ -201,17 +205,21 @@ jobs:
     - name: Remove old OpenSSL 1.1
       run: brew uninstall openssl@1.1
     - name: Install dependencies
-      run: brew install autoconf automake fltk openssl@3
+      run: brew install autoconf automake fltk@1.3 openssl@3
     - name: autogen
       run: ./autogen.sh
     - name: configure
-      run: ./configure --disable-mbedtls
+      run: |
+        export PATH="/usr/local/opt/fltk@1.3/bin:$PATH"
+        ./configure --disable-mbedtls
     - name: make
       run: make
     - name: make check
       run: make check
     - name: make distcheck
-      run: make distcheck
+      run: |
+        export PATH="/usr/local/opt/fltk@1.3/bin:$PATH"
+        make distcheck
   freebsd-14-openssl-3:
     needs: ubuntu-latest-html-tests
     runs-on: ubuntu-latest

--- a/doc/install.md
+++ b/doc/install.md
@@ -144,7 +144,7 @@ autoconf and automake if you are building Dillo from the git repository.
 They are available in the Homebrew package manager:
 
 ```
-$ brew install autoconf automake fltk
+$ brew install autoconf automake fltk@1.3
 ```
 
 For OpenSSL you can use either 1.1 or 3.X (recommended):


### PR DESCRIPTION
Homebrew has updated the default version of FLTK to 1.4, which is causing rendering issues in Dillo. So for now, we build with FLTK 1.3 by pinning it.

See: https://github.com/Homebrew/homebrew-core/pull/198029
See: https://github.com/dillo-browser/dillo/issues/246