### PR TITLE
Allow image formats to be disabled from dillorc

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,7 @@ dillo-3.2.0 [Not released yet]
  - Improve image resize logic to always try to preserve the aspect ratio.
  - Reload current page on SIGUSR1 signal
  - Print library versions and enabled features with dillo -v.
+ - Allow image formats to be ignored with the "ignore_image_formats" option.
    Patches: Rodrigo Arias Mallo
 +- Add primitive support for SVG using the nanosvg.h library.
  - Add support for ch, rem, vw, vh, vmin and vmax CSS units.

--- a/dillorc
+++ b/dillorc
@@ -19,6 +19,12 @@
 # menu.)
 #load_images=YES
 
+# A space separated list of image formats that will be ignored (not viewed).
+# An option to download the image will be offered instead.
+# Available formats: gif, png, webp, jpeg and svg.
+# ignore_image_formats="webp svg"
+#ignore_image_formats=""
+
 # Change this if you want background images to be loaded initially.
 # (While browsing, this can be changed from the tools/settings menu.)
 #load_background_images=NO

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -76,6 +76,7 @@ void a_Prefs_init(void)
    prefs.adjust_min_width = TRUE;
    prefs.adjust_table_min_width = TRUE;
    prefs.load_images=TRUE;
+   prefs.ignore_image_formats = NULL;
    prefs.load_background_images=FALSE;
    prefs.load_stylesheets=TRUE;
    prefs.middle_click_drags_page = TRUE;

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -97,6 +97,7 @@ typedef struct {
    bool_t show_quit_dialog;
    bool_t fullwindow_start;
    bool_t load_images;
+   char *ignore_image_formats;
    bool_t load_background_images;
    bool_t load_stylesheets;
    bool_t parse_embedded_css;

--- a/src/prefsparser.cc
+++ b/src/prefsparser.cc
@@ -186,6 +186,7 @@ void PrefsParser::parse(FILE *fp)
       { "adjust_min_width", &prefs.adjust_min_width, PREFS_BOOL, 0 },
       { "adjust_table_min_width", &prefs.adjust_table_min_width, PREFS_BOOL, 0 },
       { "load_images", &prefs.load_images, PREFS_BOOL, 0 },
+      { "ignore_image_formats", &prefs.ignore_image_formats, PREFS_STRING, 0 },
       { "load_background_images", &prefs.load_background_images, PREFS_BOOL, 0 },
       { "load_stylesheets", &prefs.load_stylesheets, PREFS_BOOL, 0 },
       { "middle_click_drags_page", &prefs.middle_click_drags_page,

--- a/src/version.cc
+++ b/src/version.cc
@@ -37,7 +37,11 @@ static void print_libs()
 
    /* FLTK only offers a single number */
    {
+#if FL_MAJOR_VERSION == 1 && FL_MINOR_VERSION == 3 && FL_PATCH_VERSION <= 3
+      int fltkver = Fl::version();
+#else
       int fltkver = Fl::api_version();
+#endif
       int fltk_maj = fltkver / 10000;
       int fltk_min = (fltkver / 100) % 100;
       int fltk_pat = fltkver % 100;


### PR DESCRIPTION
Makes disabling certain formats posible without the need to rebuild Dillo from source.

See: https://github.com/dillo-browser/dillo/pull/312