### PR TITLE
Add git commit to the reported version with -v

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -711,6 +711,29 @@ if eval "test x$GCC = xyes"; then
   CXXFLAGS="$CXXFLAGS -Wall -W -Wno-unused-parameter -fno-rtti -fno-exceptions -pedantic -std=c++11 -D_POSIX_C_SOURCE=200112L"
 fi
 
+dnl ----------------------------------
+dnl Check if we can use the git commit
+dnl ----------------------------------
+git_ok=no
+AC_CHECK_PROG(git_found, git, yes, no)
+if test "x$git_found" = "xyes" ; then
+  AC_MSG_CHECKING([.git directory exists])
+  if test -d "$srcdir/.git"; then
+    AC_MSG_RESULT([yes])
+    AC_MSG_CHECKING(git describe works)
+    git_version=`git --work-tree="$srcdir" describe --dirty`
+    if test "x$git_version" = "x"; then
+      AC_MSG_RESULT(no)
+    else
+      git_ok=yes
+      AC_MSG_RESULT([yes ($git_version)])
+    fi
+  else
+    AC_MSG_RESULT([no])
+  fi
+fi
+AM_CONDITIONAL([GIT_AVAILABLE],  [test "x$git_ok" = "xyes"])
+
 AC_SUBST(BASE_CUR_WORKING_DIR)
 AC_SUBST(LIBJPEG_LIBS)
 AC_SUBST(LIBJPEG_LDFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -138,5 +138,21 @@ dillo_SOURCES = \
 	xembed.cc \
 	xembed.hh
 
+# https://www.gnu.org/software/automake/manual/html_node/Built-Sources-Example.html
+nodist_dillo_SOURCES = commit.h
+dillo.$(OBJEXT): commit.h
+CLEANFILES = commit.h
+
+if GIT_AVAILABLE
+# Always rebuild
+.PHONY: commit.h
+commit.h:
+	printf '#define GIT_COMMIT "%s"\n' `git --work-tree="$(top_srcdir)" describe --dirty` > commit.h
+else
+# No need to rebuild
+commit.h:
+	echo "" > commit.h
+endif # GIT_AVAILABLE
+
 dist_sysconf_DATA = domainrc keysrc hsts_preload
 EXTRA_DIST = chg srch

--- a/src/version.cc
+++ b/src/version.cc
@@ -18,6 +18,7 @@
  */
 
 #include "config.h"
+#include "commit.h"
 
 #include "djpeg.h"
 #include "dpng.h"
@@ -114,7 +115,13 @@ static void print_features()
 
 void a_Version_print_info(void)
 {
-   printf("Dillo version " VERSION "\n");
+   const char *version = "v" VERSION;
+
+#ifdef GIT_COMMIT
+   version = GIT_COMMIT;
+#endif
+
+   printf("Dillo %s\n", version);
    print_libs();
    print_features();
 }


### PR DESCRIPTION
When git is available, records the git commit in the dillo binary, so dillo -v reports the version and the commit. Otherwise only the release version is reported (as we do now).

The commit is *always* recomputed when "make" is called. This allows switching branches, doing a dirty rebuild and still get the correct commit with "dillo -v".

Using AC_INIT() doesn't update the commit when the source is already configured.

Fixes: https://github.com/dillo-browser/dillo/issues/288