### PR TITLE
Fix build error for missing commit.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -140,7 +140,7 @@ dillo_SOURCES = \
 
 # https://www.gnu.org/software/automake/manual/html_node/Built-Sources-Example.html
 nodist_dillo_SOURCES = commit.h
-dillo.$(OBJEXT): commit.h
+version.$(OBJEXT) dillo.$(OBJEXT): commit.h
 CLEANFILES = commit.h
 
 if GIT_AVAILABLE


### PR DESCRIPTION
Add the target commit.h as a dependency of version.o, so it gets
generated before being included in version.cc, otherwise when doing a
parallel build it can fail.
