### PR TITLE
Add support for user actions in the link menu

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,8 @@ dillo-3.2.0 [Not released yet]
  - Reload current page on SIGUSR1 signal
  - Print library versions and enabled features with dillo -v.
  - Allow image formats to be ignored with the "ignore_image_formats" option.
+ - Add the "link_action" option to define custom menu entries to open links
+   with external programs or scripts.
    Patches: Rodrigo Arias Mallo
 +- Add primitive support for SVG using the nanosvg.h library.
  - Add support for ch, rem, vw, vh, vmin and vmax CSS units.

--- a/dillorc
+++ b/dillorc
@@ -64,6 +64,17 @@
 # jump to a given position.
 #scrollbar_page_mode=NO
 
+# Define custom actions for the link menu. The format is <label>:<cmd>. The
+# command will be executed in the system shell using the system() call. You can
+# implement your own handling logic in a script or program. The following
+# environment variables are set:
+#   $url:    URL being opened
+#   $origin: URL of the current document
+# Examples:
+# link_action="Debug variables:echo url=$url origin=$origin"
+# link_action="Open in MPV:mpv $url"
+# link_action="Open in Firefox:firefox $url"
+
 #-------------------------------------------------------------------------
 #                           RENDERING SECTION
 #-------------------------------------------------------------------------

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,6 +39,8 @@ dillo_SOURCES = \
 	bw.c \
 	cookies.c \
 	cookies.h \
+	actions.c \
+	actions.h \
 	hsts.c \
 	hsts.h \
 	auth.c \

--- a/src/actions.c
+++ b/src/actions.c
@@ -1,0 +1,65 @@
+/*
+ * File: actions.c
+ *
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "actions.h"
+#include "msg.h"
+#include "../dlib/dlib.h"
+#include <errno.h>
+
+static Dlist *link_actions = NULL;
+
+void
+action_parse(char *line)
+{
+   char *label = strtok(line, ":");
+
+   if (label == NULL || strlen(label) == 0) {
+      MSG("Missing action label, ignoring '%s'\n", line);
+      return;
+   }
+
+   //MSG("Got label='%s'\n", label);
+
+   char *cmd = strtok(NULL, "");
+
+   if (cmd == NULL || strlen(cmd) == 0) {
+      MSG("Missing action command, ignoring '%s'\n", line);
+      return;
+   }
+
+   //MSG("Got action label='%s' cmd='%s'\n", label, cmd);
+
+   Action *action = dMalloc(sizeof(Action));
+   action->label = dStrdup(label);
+   action->cmd = dStrdup(cmd);
+
+   dList_append(link_actions, action);
+}
+
+void
+a_Actions_init(void)
+{
+   int n = dList_length(prefs.link_actions);
+
+   link_actions = dList_new(n);
+
+   for (int i = 0; i < n; i++) {
+      char *line = dList_nth_data(prefs.link_actions, i);
+      if (line)
+         action_parse(line);
+   }
+}
+
+Dlist *
+a_Actions_link_get(void)
+{
+   return link_actions;
+}

--- a/src/actions.h
+++ b/src/actions.h
@@ -1,0 +1,32 @@
+/*
+ * File: actions.h
+ *
+ * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef ACTIONS_H
+#define ACTIONS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include "dlib/dlib.h"
+
+typedef struct {
+   char *label;
+   char *cmd;
+} Action;
+
+void a_Actions_init(void);
+Dlist *a_Actions_link_get(void);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* ACTIONS_H*/

--- a/src/dillo.cc
+++ b/src/dillo.cc
@@ -57,6 +57,7 @@
 #include "capi.h"
 #include "dicache.h"
 #include "cookies.h"
+#include "actions.h"
 #include "hsts.h"
 #include "domain.h"
 #include "auth.h"
@@ -489,6 +490,7 @@ int main(int argc, char **argv)
    a_Dicache_init();
    a_Bw_init();
    a_Cookies_init();
+   a_Actions_init();
    a_Hsts_init(Paths::getPrefsFP(PATHS_HSTS_PRELOAD));
    a_Auth_init();
    a_UIcmd_init();

--- a/src/html.cc
+++ b/src/html.cc
@@ -780,7 +780,7 @@ bool DilloHtml::HtmlLinkReceiver::press (Widget *widget, int link, int img,
             a_UIcmd_page_popup(bw, bw->num_page_bugs != 0, html->cssUrls);
             ret = true;
          } else {
-            a_UIcmd_link_popup(bw, html->links->get(link));
+            a_UIcmd_link_popup(bw, html->links->get(link), html->page_url);
             ret = true;
          }
       }

--- a/src/menu.hh
+++ b/src/menu.hh
@@ -9,7 +9,8 @@ extern "C" {
 
 void a_Menu_page_popup(BrowserWindow *bw, const DilloUrl *url,
                        bool_t has_bugs, void *v_cssUrls);
-void a_Menu_link_popup(BrowserWindow *bw, const DilloUrl *url);
+void a_Menu_link_popup(BrowserWindow *bw, const DilloUrl *url,
+                       const DilloUrl *page_url);
 void a_Menu_image_popup(BrowserWindow *bw, const DilloUrl *url,
                         bool_t loaded_img, DilloUrl *page_url,
                         DilloUrl *link_url);

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -85,6 +85,7 @@ void a_Prefs_init(void)
    prefs.scroll_switches_tabs = TRUE;
    prefs.scroll_switches_tabs_reverse = FALSE;
    prefs.no_proxy = dStrdup(PREFS_NO_PROXY);
+   prefs.link_actions = dList_new(16);
    prefs.panel_size = P_medium;
    prefs.parse_embedded_css=TRUE;
    prefs.save_dir = dStrdup(PREFS_SAVE_DIR);

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -124,6 +124,7 @@ typedef struct {
    int penalty_hyphen, penalty_hyphen_2;
    int penalty_em_dash_left, penalty_em_dash_right, penalty_em_dash_right_2;
    int stretchability_factor;
+   Dlist *link_actions;
 } DilloPrefs;
 
 /** Global Data */

--- a/src/prefsparser.cc
+++ b/src/prefsparser.cc
@@ -248,6 +248,7 @@ void PrefsParser::parse(FILE *fp)
         PREFS_FRACTION_100, 0 },
       { "stretchability_factor", &prefs.stretchability_factor,
         PREFS_FRACTION_100, 0 },
+      { "link_action", &prefs.link_actions, PREFS_STRINGS, 0 },
       { "zoom_factor", &prefs.zoom_factor, PREFS_DOUBLE, 0 }
    };
    // changing the LC_NUMERIC locale (temporarily) to C

--- a/src/uicmd.cc
+++ b/src/uicmd.cc
@@ -1269,9 +1269,9 @@ void a_UIcmd_page_popup(void *vbw, bool_t has_bugs, void *v_cssUrls)
 /*
  * Popup the link menu
  */
-void a_UIcmd_link_popup(void *vbw, const DilloUrl *url)
+void a_UIcmd_link_popup(void *vbw, const DilloUrl *url, const DilloUrl *page_url)
 {
-   a_Menu_link_popup((BrowserWindow*)vbw, url);
+   a_Menu_link_popup((BrowserWindow*)vbw, url, page_url);
 }
 
 /*

--- a/src/uicmd.hh
+++ b/src/uicmd.hh
@@ -59,7 +59,7 @@ void a_UIcmd_findbar_toggle(BrowserWindow *bw, int on);
 void a_UIcmd_focus_main_area(BrowserWindow *bw);
 void a_UIcmd_focus_location(void *vbw);
 void a_UIcmd_page_popup(void *vbw, bool_t has_bugs, void *v_cssUrls);
-void a_UIcmd_link_popup(void *vbw, const DilloUrl *url);
+void a_UIcmd_link_popup(void *vbw, const DilloUrl *url, const DilloUrl *page_url);
 void a_UIcmd_image_popup(void *vbw, const DilloUrl *url, bool_t loaded_img,
                          DilloUrl *page_url, DilloUrl *link_url);
 void a_UIcmd_form_popup(void *vbw, const DilloUrl *url, void *vform,


### PR DESCRIPTION
Allows the user to define additional entries in the link menu which will
execute the given program/script. Each actions is defined using the
"link_action" option. The link URL is stored in the $url enviroment
variable and the current page in $origin, so the user can customize how
do the handling.

Here is a simple example to add three new entries:

    link_action="Debug variables:echo url=$url origin=$origin"
    link_action="Open in MPV:mpv $url"
    link_action="Open in Firefox:firefox $url"

The command is spawned in a forked process using the system() call,
which uses the shell to expand any variable. In particular, the $url
variable is set to the current URL being opened.
