### PR TITLE
Support line fragments in plain text files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -31,6 +31,7 @@ dillo-3.2.0 [Not released yet]
  - Allow image formats to be ignored with the "ignore_image_formats" option.
  - Add the "link_action" option to define custom menu entries to open links
    with external programs or scripts.
+ - Add support for line fragments in plain text files (file://foo/bar.txt#L42).
    Patches: Rodrigo Arias Mallo
 +- Add primitive support for SVG using the nanosvg.h library.
  - Add support for ch, rem, vw, vh, vmin and vmax CSS units.

--- a/src/plain.cc
+++ b/src/plain.cc
@@ -54,6 +54,7 @@ public:
    style::Style *widgetStyle;
    size_t Start_Ofs;    /* Offset of where to start reading next */
    int state;
+   long currentLine;
 
    DilloPlain(BrowserWindow *bw);
    ~DilloPlain();
@@ -95,6 +96,7 @@ DilloPlain::DilloPlain(BrowserWindow *p_bw)
    dw = new Textblock (prefs.limit_text_width);
    Start_Ofs = 0;
    state = ST_SeekingEol;
+   currentLine = 0L;
 
    Layout *layout = (Layout*) bw->render_layout;
    // TODO (1x) No URL?
@@ -141,6 +143,10 @@ void DilloPlain::addLine(char *Buf, uint_t BufSize)
    int len;
    char buf[129];
    char *end = Buf + BufSize;
+
+   currentLine++; /* Start at 1 */
+   sprintf(buf, "L%ld", currentLine); /* Always fits */
+   DW2TB(dw)->addAnchor(buf, widgetStyle);
 
    if (BufSize > 0) {
       // Limit word length to avoid X11 coordinate


### PR DESCRIPTION
Line numbers can be referenced using the fragment L + line number. For
example, file://foo/bar.txt#L42 will cause Dillo to scroll to line 42.

Fixes: https://github.com/dillo-browser/dillo/issues/330
