### PR TITLE
Print error if dpi_dir cannot be opened

### DIFF
--- a/dpid/main.c
+++ b/dpid/main.c
@@ -1,7 +1,8 @@
 /*
    Copyright (C) 2003  Ferdi Franceschini <ferdif@optusnet.com.au>
-                 2020  Axel Beckert <abe@debian.org>
-                 2023  Michal Grezl <walley@walley.org>
+   Copyright (C) 2020  Axel Beckert <abe@debian.org>
+   Copyright (C) 2023  Michal Grezl <walley@walley.org>
+   Copyright (C) 2025  Rodrigo Arias Mallo <rodarima@gmail.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -294,7 +295,7 @@ int main(void)
    (void) sigemptyset(&mask_none);
    (void) sigprocmask(SIG_SETMASK, &mask_none, NULL);
 
-   printf("dpid started\n");
+   printf("dpid started (found %d dpis)\n", numdpis);
 /* Start main loop */
    while (1) {
       do {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -150,7 +150,7 @@ if GIT_AVAILABLE
 # if the version is different to avoid rebuilds.
 commit.h: commit.tmp.h
 	test -f $@ || (echo "" > $@)
-	if diff $@ $^ >/dev/null; then rm $^; else mv $^ $@; fi
+	if diff $@ $^ >/dev/null; then rm $^; else mv -f $^ $@; fi
 
 commit.tmp.h:
 	printf '#define GIT_COMMIT "%s"\n' `git --work-tree="$(top_srcdir)" describe --dirty` > $@


### PR DESCRIPTION
On cases where the system directory cannot be opened, dpid will not load the builtin plugins causing Dillo to fail to work properly with file: or data: URLs. Reporting a failure to open the directory allows users to determine the cause of the problem.

See: https://github.com/dillo-browser/dillo/issues/337