### PR TITLE
configure with IPv6 on by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,9 +37,9 @@ AC_ARG_ENABLE([insure],
   [enable_insure=no])
 
 AC_ARG_ENABLE([ipv6],
-  [AS_HELP_STRING([--enable-ipv6], [Build with support for IPv6])],
+  [AS_HELP_STRING([--disable-ipv6], [Disable support for IPv6])],
   [enable_ipv6=$enableval],
-  [enable_ipv6=no])
+  [enable_ipv6=yes])
 
 AC_ARG_ENABLE([cookies],
   [AS_HELP_STRING([--disable-cookies], [Dont compile support for cookies])],


### PR DESCRIPTION
Provide an argument to disable IPv6, inverting previous behaviour.

Realised that I had to enable IPv6 specifically when surfing on OS X 10.4.