### PR TITLE
Fix text under scrollbar on the left

### DIFF
--- a/dw/layout.cc
+++ b/dw/layout.cc
@@ -2,7 +2,7 @@
  * Dillo Widget
  *
  * Copyright 2005-2007 Sebastian Geerken <sgeerken@dillo.org>
- * Copyright 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ * Copyright 2024-2025 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -969,6 +969,11 @@ void Layout::resizeIdle ()
                DBG_OBJ_SET_SYM ("canvasHeightGreater",
                                 canvasHeightGreater ? "true" : "false");
                containerSizeChanged ();
+
+               // We need to place the top level widget at an offset, so
+               // be sure that we allocate it with the new allocation.x
+               if (view->getScrollbarOnLeft())
+                  topLevel->setFlags(Widget::NEEDS_ALLOCATE);
             }
 
             // Set viewport sizes.

--- a/test/html/manual/left-scrollbar.html
+++ b/test/html/manual/left-scrollbar.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test text under left scrollbar</title>
+    <style>
+    body { width: 700px; height: 1000px; }
+    </style>
+  </head>
+  <body>
+    <p>
+      Can you read me?
+      <em>You must set the scrollbar_on_left=YES config option</em>
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
When the page is first layouted, we can then determine if the vertical scrollbar needs to be present. When the vertical scrollbar is on the left side, the whole content needs to be shifted to the right, so we need to allocate the top level widget again. The current fix simply marks the top level widget for allocation.

Fixes: https://github.com/dillo-browser/dillo/issues/359