### PR TITLE
Add .deps/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.a
 *.o
+.deps/
 config.*
 autom4te.cache
 Makefile


### PR DESCRIPTION
The .deps folders are part of the build process and dirty git status. This ignores them in the project.