### PR TITLE
Add logging of DPI commands from server

### DIFF
--- a/dpid/dpid_common.c
+++ b/dpid/dpid_common.c
@@ -33,6 +33,7 @@ ssize_t ckd_write(int fd, char *msg, char *file, int line)
 {
    ssize_t ret;
 
+   MSG_COMM_SEND("%s\n", msg);
    do {
       ret = write(fd, msg, strlen(msg));
    } while (ret == -1 && errno == EINTR);

--- a/dpid/dpid_common.h
+++ b/dpid/dpid_common.h
@@ -21,6 +21,8 @@
 #define _MSG(...)
 #define MSG(...)  printf("[dpid]: " __VA_ARGS__)
 #define MSG_ERR(...)  fprintf(stderr, "[dpid]: " __VA_ARGS__)
+#define MSG_COMM_RECV(...)  fprintf(stderr, "[dpid]: RECV - " __VA_ARGS__)
+#define MSG_COMM_SEND(...)  fprintf(stderr, "[dpid]: SEND - " __VA_ARGS__)
 
 #define dotDILLO_DPI ".dillo/dpi"
 #define dotDILLO_DPIDRC ".dillo/dpidrc"

--- a/dpid/main.c
+++ b/dpid/main.c
@@ -142,6 +142,10 @@ static char *get_request(Dsh *sh)
    dpip_tag = a_Dpip_dsh_read_token(sh, 1);
    (void) sigprocmask(SIG_UNBLOCK, &mask_sigchld, NULL);
 
+   if (dpip_tag) {
+      MSG_COMM_RECV("%s\n", dpip_tag);
+   }
+
    return dpip_tag;
 }
 


### PR DESCRIPTION
I'm looking at dpid to get a sense of what it's doing. There's not a whole ton of documentation about the protocol. I've added a few logging macros and put them into the right places to better see the messages flowing in and out of the service:

```
$ ./dpid
[dpid]: get_file_type: Unknown file type for style.css
[dpid]: get_file_type: Unknown file type for style.css
[dpid]: a_Misc_mksecret: e38f370d
[dpid]: SEND - 5020 e38f370d

dpid started (found 10 dpis)
[dpid]: RECV - <cmd='auth' msg='e38f370d' '>
[dpid]: RECV - <cmd='register_all' '>
[dpid]: get_file_type: Unknown file type for style.css
[dpid]: get_file_type: Unknown file type for style.css
[dpid]: RECV - <cmd='auth' msg='e38f370d' '>
[dpid]: RECV - <cmd='DpiBye' '>
```

These are the logs generated by startup, followed by `./dpidc register` and `dpidc stop`. There's a stray newline in there because most of the dpi messages are sent without newlines, while the generated port/secret are written using the same write macro with a new line. 

Here's a few more from browsing:

```
[dpid]: RECV - <cmd='check_server' msg='bookmarks' '>
[dpid]: SEND - <cmd='send_data' msg='5030' '>
[dpid]: RECV - <cmd='check_server' msg='proto.rdrview' '>
[dpid]: SEND - <cmd='send_data' msg='5021' '>
```
