### PR TITLE
Add brotli support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Update package lists
       run: sudo apt update
     - name: Install dependencies
-      run: sudo apt install -y libfltk1.3-dev libssl-dev libpng-dev libjpeg-dev libwebp-dev xvfb x11-apps x11-utils imagemagick
+      run: sudo apt install -y libfltk1.3-dev libssl-dev libpng-dev libjpeg-dev libwebp-dev libbrotli-dev xvfb x11-apps x11-utils imagemagick
 
     - name: autogen
       run: ./autogen.sh
@@ -271,7 +271,7 @@ jobs:
         fetch-depth: 1
     - uses: cygwin/cygwin-install-action@master
       with:
-        packages: gcc-core gcc-g++ autoconf automake make zlib-devel mbedtls-devel libfltk-devel libiconv-devel libpng-devel libjpeg-devel libwebp-devel libgif-devel
+        packages: gcc-core gcc-g++ autoconf automake make zlib-devel mbedtls-devel libfltk-devel libiconv-devel libpng-devel libjpeg-devel libwebp-devel libgif-devel libbrotli-devel
     - shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
       run: |
         set -x

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,11 @@ Here we list changes that are relatively significant and/or visible to the
 user. For a history of changes in full detail, see our Git repository
 at https://github.com/dillo-browser/dillo
 
+dillo-3.3.0 [Unreleased]
+
++- Add optional support for brotli (br) content encoding.
+   Patches: Rodrigo Arias Mallo
+
 dillo-3.2.0 [Jan 18, 2025]
 
 +- Add new_tab_page option to open a custom new tab page.

--- a/configure.ac
+++ b/configure.ac
@@ -107,6 +107,11 @@ AC_ARG_ENABLE([mbedtls],
   [enable_mbedtls=$enableval],
   [enable_mbedtls=yes])
 
+AC_ARG_ENABLE([brotli],
+  [AS_HELP_STRING([--disable-brotli], [Disable support for brotli encoding])],
+  [enable_brotli=$enableval],
+  [enable_brotli=yes])
+
 AC_ARG_WITH([ca-certs-file],
   [AS_HELP_STRING([--with-ca-certs-file=FILE], [Specify where to find a bundle of trusted CA certificates for TLS])],
   CA_CERTS_FILE=$withval)
@@ -329,6 +334,33 @@ if test "x$libz_ok" = xyes; then
   LIBZ_LIBS="-lz"
 else
   AC_MSG_ERROR(zlib must be installed!)
+fi
+
+dnl ---------------
+dnl Test for brotli
+dnl ---------------
+dnl
+if test "x$enable_brotli" = "xyes"; then
+  AC_CHECK_HEADER(brotli/decode.h, brotli_ok=yes, brotli_ok=no)
+
+  if test "x$brotli_ok" = "xyes"; then
+    old_libs="$LIBS"
+    AC_CHECK_LIB(brotlidec, BrotliDecoderVersion, brotli_ok=yes, brotli_ok=no)
+    LIBS="$old_libs"
+
+    if test "x$brotli_ok" = "xyes"; then
+      BROTLI_LIBS="-lbrotlidec"
+    else
+      AC_MSG_WARN([*** libbrotlidec not found. Disabling brotli encoding.***])
+    fi
+  else
+    AC_MSG_WARN([*** brotli/decode.h not found. Disabling brotli encoding.***])
+  fi
+
+fi
+
+if test "x$brotli_ok" = "xyes"; then
+  AC_DEFINE([ENABLE_BROTLI], [1], [Enable brotli encoding])
 fi
 
 dnl ---------------
@@ -742,6 +774,7 @@ AC_SUBST(LIBPNG_LIBS)
 AC_SUBST(LIBPNG_CFLAGS)
 AC_SUBST(LIBWEBP_LIBS)
 AC_SUBST(LIBZ_LIBS)
+AC_SUBST(BROTLI_LIBS)
 AC_SUBST(LIBSSL_LIBS)
 AC_SUBST(LIBPTHREAD_LIBS)
 AC_SUBST(LIBPTHREAD_LDFLAGS)
@@ -793,6 +826,7 @@ _AS_ECHO([  PNG enabled    : ${png_ok}])
 _AS_ECHO([  GIF enabled    : ${enable_gif}])
 _AS_ECHO([  SVG enabled    : ${enable_svg}])
 _AS_ECHO([  WEBP enabled   : ${enable_webp}])
+_AS_ECHO([  Brotli enabled : ${enable_brotli}])
 _AS_ECHO([])
 _AS_ECHO([  HTML tests     : ${html_tests_ok}])
 _AS_ECHO([])

--- a/doc/install.md
+++ b/doc/install.md
@@ -35,7 +35,7 @@ packages to build Dillo:
 ```sh
 $ sudo apt install gcc g++ autoconf automake make zlib1g-dev \
     libfltk1.3-dev libssl-dev libc6-dev \
-    libpng-dev libjpeg-dev libwebp-dev
+    libpng-dev libjpeg-dev libwebp-dev libbrotli-dev
 ```
 
 If you prefer to use mbedTLS, replace `libssl-dev` with
@@ -170,7 +170,7 @@ will need the following dependencies to build Dillo with mbedTLS:
 
 ```
 gcc-core gcc-g++ autoconf automake make zlib-devel mbedtls-devel libfltk-devel
-libiconv-devel libpng-devel libjpeg-devel libwebp-devel
+libiconv-devel libpng-devel libjpeg-devel libwebp-devel libbrotli-devel
 ```
 
 **Note**: Dillo can also be built with OpenSSL (libssl-devel) but there is a
@@ -187,7 +187,7 @@ xorg-server xinit
 
 You can also install all the dependencies from the command line with:
 ```
-setup-x86_64.exe -q -P gcc-core,gcc-g++,autoconf,automake,make,zlib-devel,mbedtls-devel,libfltk-devel,libiconv-devel,libpng-devel,libjpeg-devel,libwebp-devel,xorg-server,xinit
+setup-x86_64.exe -q -P gcc-core,gcc-g++,autoconf,automake,make,zlib-devel,mbedtls-devel,libfltk-devel,libiconv-devel,libpng-devel,libjpeg-devel,libwebp-devel,libbrotli-devel,xorg-server,xinit
 ```
 
 To build Dillo, follow the usual steps from a Cygwin shell:

--- a/src/IO/http.c
+++ b/src/IO/http.c
@@ -2,7 +2,7 @@
  * File: http.c
  *
  * Copyright (C) 2000-2007 Jorge Arellano Cid <jcid@dillo.org>
- * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ * Copyright (C) 2024-2025 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -425,7 +425,11 @@ static Dstr *Http_make_query_str(DilloWeb *web, bool_t use_proxy, bool_t use_tls
          "User-Agent: %s\r\n"
          "Accept: %s\r\n"
          "%s" /* language */
-         "Accept-Encoding: gzip, deflate\r\n"
+         "Accept-Encoding: gzip, deflate"
+#ifdef ENABLE_BROTLI
+	 ", br"
+#endif
+         "\r\n"
          "%s" /* auth */
          "DNT: 1\r\n"
          "%s" /* proxy auth */
@@ -449,7 +453,11 @@ static Dstr *Http_make_query_str(DilloWeb *web, bool_t use_proxy, bool_t use_tls
          "User-Agent: %s\r\n"
          "Accept: %s\r\n"
          "%s" /* language */
-         "Accept-Encoding: gzip, deflate\r\n"
+         "Accept-Encoding: gzip, deflate"
+#ifdef ENABLE_BROTLI
+	 ", br"
+#endif
+         "\r\n"
          "%s" /* auth */
          "DNT: 1\r\n"
          "%s" /* proxy auth */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,7 +21,7 @@ dillo_LDADD = \
 	$(top_builddir)/dw/libDw-core.a \
 	$(top_builddir)/lout/liblout.a \
 	@LIBJPEG_LIBS@ @LIBPNG_LIBS@ @LIBWEBP_LIBS@ @LIBFLTK_LIBS@ @LIBZ_LIBS@ \
-	@LIBICONV_LIBS@ @LIBPTHREAD_LIBS@ @LIBX11_LIBS@ @LIBSSL_LIBS@
+	@LIBICONV_LIBS@ @LIBPTHREAD_LIBS@ @LIBX11_LIBS@ @LIBSSL_LIBS@ @BROTLI_LIBS@
 
 dillo_SOURCES = \
 	dillo.cc \


### PR DESCRIPTION
Implements support for brotli (br) content encoding.

Fixes: https://github.com/dillo-browser/dillo/issues/377