### PR TITLE
Add about:keys to show keyboard shortcuts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ at https://github.com/dillo-browser/dillo
 dillo-3.3.0 [Unreleased]
 
 +- Add optional support for brotli (br) content encoding.
+ - Add about:keys to display current keyboard shortcuts.
    Patches: Rodrigo Arias Mallo
 
 dillo-3.2.0 [Jan 18, 2025]

--- a/doc/user_help.in.html
+++ b/doc/user_help.in.html
@@ -794,6 +794,7 @@ Most actions can be issued by using a keyboard shortcut. The key bindings can be
 changed in the
 <code><a href="file:~/.dillo/keysrc">~/.dillo/keysrc</a></code> file (see the
 <a href="#keysrc">keysrc</a> section).
+To see the current key bindings go to <a href='about:keys'>about:keys</a>.
 The list of default bindings is given in the following table.
 <p>
 <table>

--- a/src/IO/about.c
+++ b/src/IO/about.c
@@ -2,7 +2,7 @@
  * File: about.c
  *
  * Copyright (C) 1999-2007 Jorge Arellano Cid <jcid@dillo.org>
- * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ * Copyright (C) 2024-2025 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,6 +32,11 @@ const char *const AboutSplash=
 "    p { margin-top: 1em; }\n"
 "    ul { margin-left: 1em; }\n"
 "    li { margin-top: 0.5em; }\n"
+"    kbd {\n"
+"      display: inline-block;\n"
+"      border: solid 1px #999;\n"
+"      padding: 1px 3px;\n"
+"    }\n"
 "  </style>\n"
 "</head>\n"
 "<body>\n"
@@ -40,12 +45,12 @@ const char *const AboutSplash=
 "<h1>Quickstart</h1>\n"
 "\n"
 "<p>Welcome to Dillo " VERSION ", a small and fast graphical web browser. To\n"
-"access the help click the question mark button <code>?</code> in the top\n"
+"access the help click the question mark button <code><kbd>?</kbd></code> in the top\n"
 "right corner at any time. Here are some tips to get you started:</p>\n"
 "\n"
 "<ul>\n"
 "  <li>The main configuration file is at <code>~/.dillo/dillorc</code>.</li>\n"
-"  <li>Most actions can also be done by using the <em>keyboard</em>.</li>\n"
+"  <li>Most actions can also be done by using the <a href='about:keys'>keyboard</a>.</li>\n"
 "  <li>Cookies are <em>disabled by default</em>.</li>\n"
 "  <li>Several Dillo plugins are available.</li>\n"
 "</ul>\n"

--- a/src/cache.c
+++ b/src/cache.c
@@ -2,7 +2,7 @@
  * File: cache.c
  *
  * Copyright 2000-2007 Jorge Arellano Cid <jcid@dillo.org>
- * Copyright 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ * Copyright 2024-2025 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -89,7 +89,6 @@ static uint_t DelayedQueueIdleId = 0;
 static CacheEntry_t *Cache_process_queue(CacheEntry_t *entry);
 static void Cache_delayed_process_queue(CacheEntry_t *entry);
 static void Cache_auth_entry(CacheEntry_t *entry, BrowserWindow *bw);
-static void Cache_entry_inject(const DilloUrl *Url, Dstr *data_ds);
 
 /**
  * Determine if two cache entries are equal (used by CachedURLs)
@@ -125,7 +124,7 @@ void a_Cache_init(void)
    {
       DilloUrl *url = a_Url_new("about:splash", NULL);
       Dstr *ds = dStr_new(AboutSplash);
-      Cache_entry_inject(url, ds);
+      a_Cache_entry_inject(url, ds);
       dStr_free(ds, 1);
       a_Url_free(url);
    }
@@ -266,7 +265,7 @@ static CacheEntry_t *Cache_entry_add(const DilloUrl *Url)
  * Inject full page content directly into the cache.
  * Used for "about:splash". May be used for "about:cache" too.
  */
-static void Cache_entry_inject(const DilloUrl *Url, Dstr *data_ds)
+void a_Cache_entry_inject(const DilloUrl *Url, Dstr *data_ds)
 {
    CacheEntry_t *entry;
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -1,3 +1,15 @@
+/*
+ * File: cache.c
+ *
+ * Copyright 2000-2009 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright 2025 Rodrigo Arias Mallo <rodarima@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
 #ifndef __CACHE_H__
 #define __CACHE_H__
 
@@ -60,6 +72,7 @@ struct CacheClient {
  * Function prototypes
  */
 void a_Cache_init(void);
+void a_Cache_entry_inject(const DilloUrl *Url, Dstr *data_ds);
 int a_Cache_open_url(void *Web, CA_Callback_t Call, void *CbData);
 int a_Cache_get_buf(const DilloUrl *Url, char **PBuf, int *BufSize);
 void a_Cache_unref_buf(const DilloUrl *Url);

--- a/src/dillo.cc
+++ b/src/dillo.cc
@@ -2,7 +2,7 @@
  * Dillo web browser
  *
  * Copyright 1999-2007 Jorge Arellano Cid <jcid@dillo.org>
- * Copyright 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ * Copyright 2024-2025 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -495,6 +495,8 @@ int main(int argc, char **argv)
    a_Auth_init();
    a_UIcmd_init();
    StyleEngine::init();
+
+   Keys::genAboutKeys();
 
    dw::core::Widget::setAdjustMinWidth (prefs.adjust_min_width);
    dw::Table::setAdjustTableMinWidth (prefs.adjust_table_min_width);

--- a/src/keys.hh
+++ b/src/keys.hh
@@ -2,7 +2,7 @@
  * Key parser
  *
  * Copyright (C) 2009 Jorge Arellano Cid <jcid@dillo.org>
- * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ * Copyright (C) 2024-2025 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -62,12 +62,14 @@ private:
    static int getKeyCode(char *keyName);
    static int getModifier(char *modifierName);
    static void parseKey(char *key, char *symbol);
+   static const char *getKeyName(int key);
 public:
    static void init();
    static void free();
    static void parse(FILE *fp);
    static KeysCommand_t getKeyCmd(void);
    static int getShortcut(KeysCommand_t cmd);
+   static void genAboutKeys(void);
 };
 
 


### PR DESCRIPTION
Fixes: https://github.com/dillo-browser/dillo/issues/66