### PR TITLE
Control + left click opens link in new tab

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ dillo-3.3.0 [Unreleased]
 
 +- Add optional support for brotli (br) content encoding.
  - Add about:keys to display current keyboard shortcuts.
+ - Control + left click opens links in new tab (emulates mouse middle button).
    Patches: Rodrigo Arias Mallo
 
 dillo-3.2.0 [Jan 18, 2025]

--- a/doc/user_help.in.html
+++ b/doc/user_help.in.html
@@ -344,18 +344,19 @@ DuckDuckGo for the keywords "dillo browser".
 <h3 id="tabs">Tabs</h3>
 <p>
 Dillo can open different web pages into tabs. To open a link in a new tab click
-the middle button instead of the left button. The same applies to buttons to
-submit a form. A new tab can also be opened from the <code>File</code> menu or
-using the shortcut <code>Ctrl+T</code>.
+the middle button instead of the left button or keep <code>Control</code>
+pressed while left-clicking a link. The same applies to buttons to submit a
+form. A new tab can also be opened from the <code>File</code> menu or using the
+shortcut <code>Ctrl+T</code>.
 <p>
-Press <code>Shift</code> while middle-clicking a link to automatically focus the
-new tab. If you want this behaviour to be the default, set the following option
+Press <code>Shift</code> while opening a page in a new tab to focus the tab. If
+you want this behaviour to be the default, set the following option
 in the <a href="#dillorc">dillorc</a> configuration file:
 <pre>
 focus_new_tab=YES
 </pre>
-If this option is set, pressing <code>Shift</code> middle-clicking will instead
-avoid focusing the new tab.
+If this option is set, pressing <code>Shift</code> will instead avoid focusing
+the new tab.
 <p>
 It is also possible to have the middle-click open a window instead of a tab. For
 this set the option:

--- a/src/html.cc
+++ b/src/html.cc
@@ -2,7 +2,7 @@
  * File: html.cc
  *
  * Copyright (C) 2005-2007 Jorge Arellano Cid <jcid@dillo.org>
- * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ * Copyright (C) 2024-2025 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -813,11 +813,21 @@ bool DilloHtml::HtmlLinkReceiver::click (Widget *widget, int link, int img,
       Html_set_link_coordinates(html, link, x, y);
 
       if (event->button == 1) {
-         a_UIcmd_open_url(bw, url);
+         if (event->state & CONTROL_MASK) {
+            if (prefs.middle_click_opens_new_tab) {
+               int focus = prefs.focus_new_tab ? 1 : 0;
+               if (event->state & SHIFT_MASK) focus = !focus;
+               a_UIcmd_open_url_nt(bw, url, focus);
+            } else {
+               a_UIcmd_open_url_nw(bw, url);
+            }
+         } else {
+            a_UIcmd_open_url(bw, url);
+         }
       } else if (event->button == 2) {
          if (prefs.middle_click_opens_new_tab) {
             int focus = prefs.focus_new_tab ? 1 : 0;
-            if (event->state == SHIFT_MASK) focus = !focus;
+            if (event->state & SHIFT_MASK) focus = !focus;
             a_UIcmd_open_url_nt(bw, url, focus);
          } else
             a_UIcmd_open_url_nw(bw, url);


### PR DESCRIPTION
Small laptops and netbooks that lack a proper 3 button touchpad make it difficult to open a new tab. Using the control modifier makes is easier to open links in new tabs. It also allows mixing it with the shift modifier to control the focus.