### PR TITLE
Don't use assert to check if realloc() failed

### DIFF
--- a/lout/container.cc
+++ b/lout/container.cc
@@ -2,6 +2,7 @@
  * Dillo Widget
  *
  * Copyright 2005-2007 Sebastian Geerken <sgeerken@dillo.org>
+ * Copyright 2025 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -140,9 +141,11 @@ void Vector::put(Object *newElement, int newPos)
    if (newPos >= numAlloc) {
       while (newPos >= numAlloc)
          numAlloc *= 2;
-      void *vp;
-      assert((vp = realloc(array, numAlloc * sizeof(Object*))));
-      if (!vp) exit(-2); // when NDEBUG is defined
+      void *vp = realloc(array, numAlloc * sizeof(Object*));
+      if (vp == NULL) {
+         perror("realloc failed");
+         exit(1);
+      }
       array = (Object**)vp;
    }
 
@@ -177,9 +180,11 @@ void Vector::insert(Object *newElement, int pos)
       if (numElements >= numAlloc) {
          // Allocated memory has to be increased.
          numAlloc *= 2;
-         void *vp;
-         assert((vp = realloc(array, numAlloc * sizeof(Object*))));
-         if (!vp) exit(-2); // when NDEBUG is defined
+         void *vp = realloc(array, numAlloc * sizeof(Object*));
+         if (vp == NULL) {
+            perror("realloc failed");
+            exit(1);
+         }
          array = (Object**)vp;
       }
 

--- a/lout/misc.cc
+++ b/lout/misc.cc
@@ -2,6 +2,7 @@
  * Dillo Widget
  *
  * Copyright 2005-2007 Sebastian Geerken <sgeerken@dillo.org>
+ * Copyright 2025 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -163,10 +164,11 @@ void BitSet::set(int i, bool val)
       int newNumBytes = numBytes;
       while (8 * i >= newNumBytes)
          newNumBytes *= 2;
-
-      void *vp;
-      assert((vp = realloc(bits, newNumBytes * sizeof(unsigned char))));
-      if (!vp) exit(-2); // when NDEBUG is defined
+      void *vp = realloc(bits, newNumBytes * sizeof(unsigned char));
+      if (vp == NULL) {
+         perror("realloc failed");
+         exit(1);
+      }
       bits = (unsigned char*)vp;
       memset(bits + numBytes, 0, newNumBytes - numBytes);
       numBytes = newNumBytes;


### PR DESCRIPTION
Avoid using assert as when building with NDEBUG defined they become a no-operation so the realloc is never done. Always perform the check and exit accordingly.