### PR TITLE
Make Ctrl+A select input text

### DIFF
--- a/dw/fltkui.cc
+++ b/dw/fltkui.cc
@@ -2,6 +2,7 @@
  * Dillo Widget
  *
  * Copyright 2005-2007 Sebastian Geerken <sgeerken@dillo.org>
+ * Copyright 2025 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -174,8 +175,8 @@ int CustInput2::handle(int e)
          return 0;
       }
       if (modifier == FL_CTRL) {
-         if (k == 'a' || k == 'e') {
-            position(k == 'a' ? 0 : size());
+         if (k == 'e') {
+            position(size());
             return 1;
          } else if (k == 'k') {
             cut(position(), size());

--- a/src/ui.cc
+++ b/src/ui.cc
@@ -127,8 +127,8 @@ int CustInput::handle(int e)
             return 0;
          }
       } else if (modifier == FL_CTRL) {
-         if (k == 'a' || k == 'e') {
-            position(k == 'a' ? 0 : size());
+         if (k == 'e') {
+            position(size());
             return 1;
          } else if (k == 'k') {
             cut(position(), size());
@@ -136,7 +136,7 @@ int CustInput::handle(int e)
          } else if (k == 'd') {
             cut(position(), position()+1);
             return 1;
-         } else if (k == 'l') {
+         } else if (k == 'a' || k == 'l') {
             // Make text selected when already focused.
             position(size(), 0);
             return 1;


### PR DESCRIPTION
The Emacs shortcut was overriding the FLTK behavior of selecting all input text.

Fixes: https://github.com/dillo-browser/dillo/issues/400