### PR TITLE
Fix newer compare output

### DIFF
--- a/test/html/driver.sh
+++ b/test/html/driver.sh
@@ -93,7 +93,7 @@ function test_file() {
   render_page "$ref_file" "$wdir/ref.png"
 
   # AE = Absolute Error count of the number of different pixels
-  diffcount=$(compare -metric AE "$wdir/html.png" "$wdir/ref.png" "$wdir/diff.png" 2>&1 || true)
+  diffcount=$(compare -metric AE "$wdir/html.png" "$wdir/ref.png" "$wdir/diff.png" 2>&1 | cut -d ' ' -f 1 || true)
 
   # The test passes only if both images are identical
   if [ "$diffcount" = "0" ]; then


### PR DESCRIPTION
The compare output command has now two numbers, so it will always fail if we compare it to "0".

```
++ compare -metric AE b-div.html_wdir/html.png b-div.html_wdir/ref.png b-div.html_wdir/diff.png
+ diffcount='0 (0)'
+ '[' '0 (0)' = 0 ']'
+ echo FAIL
FAIL
```

So we simply take the first one.