### PR TITLE
Add about:cache and about:dicache internal pages

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,7 @@ dillo-3.3.0 [Unreleased]
  - Enable IPv6 support by default if supported by the platform.
  - Focus the N-th tab with the Alt+<number> shortcut.
  - Fix vsource dpi infinite loop on musl due to unescaped "%" printf format.
+ - Add about:cache and about:dicache pages to show internal cache details.
    Patches: Rodrigo Arias Mallo
 +- Middle click on back or forward button opens page in new tab.
    Patches: Alex

--- a/dlib/dlib.c
+++ b/dlib/dlib.c
@@ -2,7 +2,7 @@
  * File: dlib.c
  *
  * Copyright (C) 2006-2007 Jorge Arellano Cid <jcid@dillo.org>
- * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ * Copyright (C) 2024-2025 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -536,6 +536,34 @@ const char *dStr_printable(Dstr *in, int maxlen)
    if (out->len >= maxlen)
       dStr_append(out, "...");
    return out->str;
+}
+
+/** Shorten string so it fits in n characters.
+ *
+ * Cuts the string src so that it fits in n by replacing the middle of
+ * the string with "...", but leaving both the start and the end.
+ *
+ * The length n must be at least 9. If the src string is already shorter
+ * than n, it is appended as-is.
+ *
+ * The resulting string is appended to out.
+ */
+void dStr_shorten(Dstr *dst, const char *src, int n)
+{
+   if (n < 9)
+      n = 9;
+
+   int len = strlen(src);
+   if (len > n) {
+      int m = n - 3;
+      int n1 = m / 2; /* First half */
+      int n2 = m - n1; /* Second half */
+      dStr_append_l(dst, src, n1);
+      dStr_append(dst, "...");
+      dStr_append(dst, &src[len - n2]);
+   } else {
+      dStr_append(dst, src);
+   }
 }
 
 /*

--- a/dlib/dlib.h
+++ b/dlib/dlib.h
@@ -1,3 +1,15 @@
+/*
+ * File: dlib.h
+ *
+ * Copyright (C) 2006-2007 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright (C) 2025 Rodrigo Arias Mallo <rodarima@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
 #ifndef __DLIB_H__
 #define __DLIB_H__
 
@@ -124,6 +136,7 @@ void dStr_sprintfa (Dstr *ds, const char *format, ...);
 int  dStr_cmp(Dstr *ds1, Dstr *ds2);
 char *dStr_memmem(Dstr *haystack, Dstr *needle);
 const char *dStr_printable(Dstr *in, int maxlen);
+void dStr_shorten(Dstr *dst, const char *src, int n);
 
 /*
  *-- dList --------------------------------------------------------------------

--- a/src/cache.c
+++ b/src/cache.c
@@ -65,6 +65,7 @@ typedef struct {
    int ExpectedSize;         /**< Goal size of the HTTP transfer (0 if unknown)*/
    int TransferSize;         /**< Actual length of the HTTP transfer */
    uint_t Flags;             /**< See Flag Defines in cache.h */
+   int Hits;                 /**< Counter of hits for the entry */
 } CacheEntry_t;
 
 
@@ -210,6 +211,7 @@ static void Cache_entry_init(CacheEntry_t *NewEntry, const DilloUrl *Url)
    NewEntry->ExpectedSize = 0;
    NewEntry->TransferSize = 0;
    NewEntry->Flags = CA_IsEmpty | CA_InProgress | CA_KeepAlive;
+   NewEntry->Hits = 0;
 }
 
 /**
@@ -391,6 +393,7 @@ int a_Cache_open_url(void *web, CA_Callback_t Call, void *CbData)
       /* URL is cached: feed our client with cached data */
       ClientKey = Cache_client_enqueue(entry->Url, Web, Call, CbData);
       Cache_delayed_process_queue(entry);
+      entry->Hits++;
 
    } else {
       /* URL not cached: create an entry, send our client to the queue,

--- a/src/cache.c
+++ b/src/cache.c
@@ -427,6 +427,8 @@ static int Cache_internal_url(CacheEntry_t *entry)
 
    if (strcmp(URL_PATH(entry->Url), "cache") == 0) {
       s = Cache_stats();
+   } else if (strcmp(URL_PATH(entry->Url), "dicache") == 0) {
+      s = a_Dicache_stats();
    }
 
    if (s != NULL) {

--- a/src/dicache.c
+++ b/src/dicache.c
@@ -10,6 +10,12 @@
  * (at your option) any later version.
  */
 
+/** @file
+ * DICache stands for Decompressed Image Cache. It holds the raw buffers (RGB)
+ * of images after they are decompressed of their respective formats (png, jpeg,
+ * gif, ...).
+ */
+
 #include <string.h>         /* for memset */
 #include <stdlib.h>
 

--- a/src/dicache.h
+++ b/src/dicache.h
@@ -1,3 +1,15 @@
+/*
+ * File: dicache.c
+ *
+ * Copyright 2000-2007 Jorge Arellano Cid <jcid@dillo.org>
+ * Copyright 2025 Rodrigo Arias Mallo <rodarima@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
 #ifndef __DICACHE_H__
 #define __DICACHE_H__
 
@@ -9,6 +21,7 @@ extern "C" {
 #include "bitvec.h"
 #include "image.hh"
 #include "cache.h"
+#include "dlib/dlib.h"
 
 /** Symbolic name to request the last version of an image */
 #define DIC_Last  -1
@@ -76,6 +89,7 @@ DICacheEntry* a_Dicache_ref(const DilloUrl *Url, int version);
 void a_Dicache_unref(const DilloUrl *Url, int version);
 void a_Dicache_cleanup(void);
 void a_Dicache_freeall(void);
+Dstr *a_Dicache_stats(void);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
These internal pages show the statistics on the current state of the network cache and decompressed image cache (dicache).

<img width="45%" alt="about-cache" src="https://github.com/user-attachments/assets/1906d695-c6e8-4732-b80e-e9d71f2f6a7b" />

<img width="45%" alt="about-dicache" src="https://github.com/user-attachments/assets/07de36a5-5916-4643-808a-1db828f82e63" />