### PR TITLE
Search for fltk-config1.3 before fltk-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -229,7 +229,7 @@ dnl Test for FLTK 1.3 library
 dnl -------------------------
 dnl
 dnl For debugging and to be user friendly
-AC_PATH_PROG(FLTK_CONFIG,fltk-config)
+AC_PATH_PROGS(FLTK_CONFIG,[fltk-config1.3 fltk-config])
 AC_MSG_CHECKING([FLTK 1.3])
 fltk_version="`$FLTK_CONFIG --version 2>/dev/null`"
 case $fltk_version in


### PR DESCRIPTION

Arch Linux has changed the default FLTK version to 1.4 and the
fltk-config program for 1.3 is renamed to fltk-config1.3.

See: https://gitlab.archlinux.org/archlinux/packaging/packages/fltk1.3/-/raw/e04fd1461dc0b6919cacfeee80a432893a4acd69/fltk1.3-1.3.11-integration.patch