### PR TITLE
Escape CSS % in printf format

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ dillo-3.3.0 [Unreleased]
  - Ctrl+C copies selected text into the clipboard so Ctrl+V works as expected.
  - Enable IPv6 support by default if supported by the platform.
  - Focus the N-th tab with the Alt+<number> shortcut.
+ - Fix vsource dpi infinite loop on musl due to unescaped "%" printf format.
    Patches: Rodrigo Arias Mallo
 +- Middle click on back or forward button opens page in new tab.
    Patches: Alex

--- a/dpi/vsource.c
+++ b/dpi/vsource.c
@@ -4,7 +4,7 @@
  * This server is an example. Play with it and modify to your taste.
  *
  * Copyright 2010-2015 Jorge Arellano Cid <jcid@dillo.org>
- * Copyright 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ * Copyright 2024-2025 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -124,7 +124,7 @@ void send_html_text(Dsh *sh, const char *url, int data_size)
                      "    white-space: pre-wrap;\n"
                      "    font-family: monospace;\n"
                      "    margin: 0;\n"
-                     "    width: 100%;\n"
+                     "    width: 100%%;\n"
                      "  }\n"
                      "  table { border:0 }\n"
                      "  td.num {\n"


### PR DESCRIPTION
The `%` symbol causes a printf format for `%;` which fails in musl, causing the loop in `dStr_vprintfa()` to continue expading the buffer.

Fixes: https://github.com/dillo-browser/dillo/issues/429