### PR TITLE
Fix hidden form inputs

### DIFF
--- a/src/form.cc
+++ b/src/form.cc
@@ -574,7 +574,7 @@ void Html_tag_open_input(DilloHtml *html, const char *tag, int tagsize)
       }
 
       /* Don't add to textbox if we are under a display:none element */
-      if (!S_TOP(html)->display_none)
+      if (a_Html_should_display(html))
          HT2TB(html)->addWidget (embed, html->backgroundStyle());
    }
    dFree(type);
@@ -687,7 +687,7 @@ void Html_tag_content_textarea(DilloHtml *html, const char *tag, int tagsize)
       textres->setEditable(false);
    Html_add_input(html, DILLO_HTML_INPUT_TEXTAREA, embed, name, NULL, false);
 
-   if (!S_TOP(html)->display_none)
+   if (a_Html_should_display(html))
       HT2TB(html)->addWidget (embed, html->backgroundStyle ());
 
    dFree(name);
@@ -781,7 +781,7 @@ void Html_tag_open_select(DilloHtml *html, const char *tag, int tagsize)
                                         attrbuf);
    }
 
-   if (!S_TOP(html)->display_none)
+   if (a_Html_should_display(html))
       HT2TB(html)->addWidget (embed, html->backgroundStyle ());
 
    Html_add_input(html, type, embed, name, NULL, false);

--- a/src/form.cc
+++ b/src/form.cc
@@ -2,7 +2,7 @@
  * File: form.cc
  *
  * Copyright 2008 Jorge Arellano Cid <jcid@dillo.org>
- * Copyright 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ * Copyright 2024-2025 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -485,7 +485,7 @@ void Html_tag_open_input(DilloHtml *html, const char *tag, int tagsize)
       resource = factory->createEntryResource(size, false, name, NULL);
    } else if (!dStrAsciiCasecmp(type, "submit")) {
       inp_type = DILLO_HTML_INPUT_SUBMIT;
-      init_str = (value) ? value : dStrdup("submit");
+      init_str = (value) ? value : dStrdup("Submit");
       resource = factory->createLabelButtonResource(init_str);
    } else if (!dStrAsciiCasecmp(type, "reset")) {
       inp_type = DILLO_HTML_INPUT_RESET;

--- a/src/form.cc
+++ b/src/form.cc
@@ -343,7 +343,9 @@ void Html_tag_open_form(DilloHtml *html, const char *tag, int tagsize)
    char *charset, *first;
    const char *attrbuf;
 
-   HT2TB(html)->addParbreak (9, html->wordStyle ());
+   /* Don't break paragraph if the form is under display:none */
+   if (a_Html_should_display(html))
+      HT2TB(html)->addParbreak (9, html->wordStyle ());
 
    if (html->InFlags & IN_FORM) {
       BUG_MSG("Nested <form>.");

--- a/src/html.cc
+++ b/src/html.cc
@@ -4026,6 +4026,17 @@ static void Html_display_listitem(DilloHtml *html)
    }
 }
 
+bool a_Html_should_display(DilloHtml *html)
+{
+   if (S_TOP(html)->display_none)
+      return false;
+
+   if (html->style()->display == DISPLAY_NONE)
+      return false;
+
+   return true;
+}
+
 /**
  * Process a tag, given as 'tag' and 'tagsize'. -- tagsize is [1 based]
  * ('tag' must include the enclosing angle brackets)

--- a/src/html_common.hh
+++ b/src/html_common.hh
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2008-2016 Jorge Arellano Cid <jcid@dillo.org>
  * Copyright (C) 2008-2014 Johannes Hofmann <Johannes.Hofmann@gmx.de>
- * Copyright (C) 2024 Rodrigo Arias Mallo <rodarima@gmail.com>
+ * Copyright (C) 2024-2025 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -288,5 +288,6 @@ bool a_Html_tag_set_valign_attr(DilloHtml *html,
                                 const char *tag, int tagsize);
 
 void a_Html_load_stylesheet(DilloHtml *html, DilloUrl *url);
+bool a_Html_should_display(DilloHtml *html);
 
 #endif /* __HTML_COMMON_HH__ */

--- a/test/html/Makefile.am
+++ b/test/html/Makefile.am
@@ -14,6 +14,7 @@ TESTS = \
 	render/b-div.html \
 	render/div-100-percent-with-padding.html \
 	render/float-img-justify.html \
+	render/form-display-none.html \
 	render/github-infinite-loop.html \
 	render/hackernews.html \
 	render/img-aspect-ratio-absolute.html \

--- a/test/html/render/form-display-none.html
+++ b/test/html/render/form-display-none.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test form inputs with display:none</title>
+    <style>
+      /* * { border: solid 1px blue; margin: 5px; padding: 5px; } */
+      .container { display: none; }
+    </style>
+  </head>
+  <body>
+    <hr>
+    <p>There are some elements below, but you shouldn't see any. Disable CSS to
+    see them.</p>
+    <!-- inherited from container -->
+    <div class="container">
+      <form method="POST" enctype="multipart/form-data">
+        <label for="text">First name:</label>
+        <input type="text" id="text" name="text">
+        <label for="cars">Choose a car:</label>
+        <select id="cars" name="cars">
+          <option value="volvo">Volvo</option>
+          <option value="saab">Saab</option>
+          <option value="fiat">Fiat</option>
+          <option value="audi">Audi</option>
+        </select>
+        <textarea name="message" rows="4" cols="30">
+          The cat was playing in the garden.
+        </textarea>
+        <input type="submit" id="submit" name="submit" value="Submit!">
+        <input type="reset" id="reset" name="reset" value="Reset!">
+        <input type="file" id="file" name="file" value="Select file...">
+        <label>
+          <input type="checkbox" id="checkbox" name="checkbox" value="">
+          Select me!
+        </label>
+        <input type="hidden" id="hidden" name="hidden" value="Hidden value">
+        <button>Hello</button>
+      </form>
+    </div>
+    <hr>
+    <p>The ones below are outside the form</p>
+    <input style="display: none" type="text" name="out-text">
+    <hr>
+  </body>
+</html>

--- a/test/html/render/form-display-none.ref.html
+++ b/test/html/render/form-display-none.ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test form inputs with display:none</title>
+    <style>
+      /* * { border: solid 1px blue; margin: 5px; padding: 5px; } */
+    </style>
+  </head>
+  <body>
+    <hr>
+    <p>There are some elements below, but you shouldn't see any. Disable CSS to
+    see them.</p>
+    <hr>
+    <p>The ones below are outside the form</p>
+    <hr>
+  </body>
+</html>


### PR DESCRIPTION
Handle display:none properly for form elements. This is specially notable in the wikipedia.

Fixes #433 