### PR TITLE
Fix hr width exceeding available space

### DIFF
--- a/dw/ruler.cc
+++ b/dw/ruler.cc
@@ -2,6 +2,7 @@
  * Dillo Widget
  *
  * Copyright 2005-2007 Sebastian Geerken <sgeerken@dillo.org>
+ * Copyright 2025 Rodrigo Arias Mallo <rodarima@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,7 +42,10 @@ Ruler::~Ruler ()
 
 void Ruler::sizeRequestSimpl (core::Requisition *requisition)
 {
-   requisition->width = lout::misc::max (getAvailWidth (true), boxDiffWidth ());
+   /* The ruler will be drawn by using a 1px border, so we substract the
+    * border from the available width when computing the content width. */
+   int w = lout::misc::max(0, getAvailWidth(true) - boxDiffWidth());
+   requisition->width = w;
    requisition->ascent = boxOffsetY ();
    requisition->descent = boxRestHeight ();
 }

--- a/test/html/Makefile.am
+++ b/test/html/Makefile.am
@@ -18,6 +18,7 @@ TESTS = \
 	render/form-display-none.html \
 	render/github-infinite-loop.html \
 	render/hackernews.html \
+	render/hr.html \
 	render/img-aspect-ratio-absolute.html \
 	render/img-aspect-ratio-div.html \
 	render/img-aspect-ratio-mix-border.html \

--- a/test/html/render/hr.html
+++ b/test/html/render/hr.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test hr length</title>
+  </head>
+  <body>
+    <hr>
+    <hr style="border-width: 10px">
+  </body>
+</html>

--- a/test/html/render/hr.ref.html
+++ b/test/html/render/hr.ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test hr length</title>
+  </head>
+<style>
+div {
+  border: 1px inset;
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+</style>
+  <body>
+    <!--
+      Default canvas width is 780, with 5 pixels of margin for body on each
+      side, so we have 770 pixels of space available before the scrollbar is
+      shown. The ruler needs one pixel on each side by default, so 768 px is the
+      available width.
+    -->
+    <div style="width: 768px"></div>
+    <!-- Same but with 20 pixels for the ruler border -->
+    <div style="width: 750px; border-width: 10px"></div>
+  </body>
+</html>


### PR DESCRIPTION
The hr ruler was directly using the available content width to compute its allocation. However, the width needs to take into account the border of the hr element (1 pixel on each side) to avoid making the element larger than the available space.

Co-authored-by: dogma