### PR TITLE
Increase horizontal margin in the location bar

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,7 @@ dillo-3.3.0 [Unreleased]
  - Add about:cache and about:dicache pages to show internal cache details.
  - Add mojeek search engine with shortcut "mj".
  - Hide form elements (like buttons and inputs) with display:none in CSS.
+ - Increase margin in location bar to make it easier to select with the mouse.
    Patches: Rodrigo Arias Mallo
 +- Middle click on back or forward button opens page in new tab.
    Patches: Alex

--- a/src/ui.cc
+++ b/src/ui.cc
@@ -90,13 +90,26 @@ static struct iconset *icons = &standard_icons;
 
 //----------------------------------------------------------------------------
 
+#define DILLO_INPUTBOX (Fl_Boxtype) (FL_FREE_BOXTYPE + 1)
+
 /**
  * Used to avoid certain shortcuts in the location bar
  */
 class CustInput : public TipWinInput {
 public:
+   static const int margin_x = 3;
    CustInput (int x, int y, int w, int h, const char* l=0) :
-      TipWinInput(x,y,w,h,l) {};
+      TipWinInput(x,y,w,h,l) {
+         /* Increase the margin of the current box by making a new clone
+          * of the current box with extra margin on dx. */
+         Fl_Boxtype b = box();
+         Fl::set_boxtype(DILLO_INPUTBOX, Fl::get_boxtype(b),
+               Fl::box_dx(b) + margin_x,
+               Fl::box_dy(b),
+               Fl::box_dw(b) + margin_x,
+               Fl::box_dh(b));
+         box(DILLO_INPUTBOX);
+      }
    virtual int handle(int e);
 };
 


### PR DESCRIPTION
Allows users to begin selecting the text or position the cursor at the beginning of the URL without requiring a high accuracy, as now there are at least 5 pixels of leading space.

Fixes: https://github.com/dillo-browser/dillo/issues/442

See before and after:

<img width="780" height="148" alt="dd" src="https://github.com/user-attachments/assets/a587ddef-70aa-492a-b717-fded378a38ff" />